### PR TITLE
Build on windows + ci enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,33 @@
-dist: trusty
-sudo: require
+language: rust
+
+sudo: required
+
+rust:
+  - stable
+  - beta
+  - nightly
+
+os:
+  - windows
+  - linux
+  - osx
+
+matrix:
+  allow_failures:
+    - rust: nightly
 
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
-      - gcc-6
-      - g++-6
       - cmake
+      - gcc
 
 language: rust
 
 cache: cargo
 
-rust:
-  - stable
-  - nightly
-
-matrix:
-  allow_failures:
-    - rust: nightly
-  fast_finish: true
-
 script:
-  - cargo test --all
-  - cargo test --all --features no_secure
+  - cargo test --verbose --all
+  - cargo test --verbose --all --no-default-features
+  - cargo test --release --verbose --all
+  - cargo test --release --verbose --all --no-default-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ os:
   - linux
   - osx
 
+dist: xenial
+
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "mimalloc"
 version = "0.1.2"
-authors = ["Octavian Oncescu <octavonce@gmail.com>"]
+authors = [
+    "Octavian Oncescu <octavonce@gmail.com>",
+    "Vincent Rouillé <vincent@speedy37.fr>",
+]
 edition = "2018"
 repository = "https://github.com/purpleprotocol/mimalloc_rust"
 keywords = ["mimalloc", "allocator", "encrypted-heap", "performance"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ description = "Performance and security oriented drop-in allocator"
 license = "MIT"
 readme = "README.md"
 
+[workspace]
+members = ["libmimalloc-sys" ]
+
 [badges]
 travis-ci = { repository = "purpleprotocol/mimalloc_rust" }
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Mimalloc Rust
+
 [![Build Status](https://travis-ci.org/purpleprotocol/mimalloc_rust.svg?branch=master)](https://travis-ci.org/purpleprotocol/mimalloc_rust) [![Latest Version]][crates.io] [![Documentation]][docs.rs]
 
 A drop-in global allocator wrapper around the [mimalloc](https://github.com/microsoft/mimalloc) allocator.
 Mimalloc is a general purpose, performance oriented allocator built by Microsoft.
 
 ## Usage
+
 ```rust
 use mimalloc::MiMalloc;
 
@@ -12,9 +14,17 @@ use mimalloc::MiMalloc;
 static GLOBAL: MiMalloc = MiMalloc;
 ```
 
+## Requirements
+
+[CMake](https://cmake.org/) and a __C__ compiler are required for building 
+[mimalloc](https://github.com/microsoft/mimalloc) with cargo.
+
 ## Usage without secure mode
-By default this library builds mimalloc in secure mode. This means that
-heap allocations are encrypted, but this results in a 3% increase in overhead.
+
+By default this library builds mimalloc in secure mode. This add guard pages, 
+randomized allocation, encrypted free lists, etc. The performance penalty should 
+only be around 3% according to [mimalloc](https://github.com/microsoft/mimalloc)
+own benchmarks.
 
 To disable secure mode, in `Cargo.toml`:
 ```rust

--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -31,9 +31,7 @@ fn main() {
     } else {
         if cfg!(debug_assertions) {
             ("./build", "mimalloc-debug")
-        } else if cfg!(feature = "secure") {
-            ("./build", "mimalloc")
-        } else {
+        } else  {
             ("./build", "mimalloc")
         }
     };

--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -1,32 +1,47 @@
 use cmake::Config;
 
-#[cfg(not(feature = "secure"))]
 fn main() {
-    let mut dst = Config::new("c_src/mimalloc")    
-        .build();
+    let mut cfg = &mut Config::new("c_src/mimalloc");
 
-    dst.push("build");
+    cfg = cfg.define("MI_OVERRIDE", "OFF");
+
+    if cfg!(feature = "secure") {
+        cfg = cfg.define("MI_SECURE", "OFF");
+    }
+
+    if cfg!(all(windows, target_env = "msvc")) {
+        // cc::get_compiler have /nologo /MD default flags that are cmake::Config
+        // defaults to. Those flags prevents mimalloc from building on windows
+        // extracted from default cmake configuration on windows
+        if cfg!(debug_assertions) {
+            // CMAKE_C_FLAGS + CMAKE_C_FLAGS_DEBUG
+            cfg = cfg.cflag("/DWIN32 /D_WINDOWS /W3 /MDd /Zi /Ob0 /Od /RTC1");
+        } else {
+            // CMAKE_C_FLAGS + CMAKE_C_FLAGS_RELEASE
+            cfg = cfg.cflag("/DWIN32 /D_WINDOWS /W3 /MD /O2 /Ob2 /DNDEBUG");
+        }
+    }
+
+    let (out_dir, out_name) = if cfg!(all(windows, target_env = "msvc")) {
+        if cfg!(debug_assertions) {
+            ("./build/Debug", "mimalloc-static-debug")
+        } else {
+            ("./build/Release", "mimalloc-static")
+        }
+    } else {
+        if cfg!(debug_assertions) {
+            ("./build", "mimalloc-debug")
+        } else if cfg!(feature = "secure") {
+            ("./build", "mimalloc")
+        } else {
+            ("./build", "mimalloc")
+        }
+    };
+
+    // Build mimalloc-static
+    let mut dst = cfg.build_target("mimalloc-static").build();
+    dst.push(out_dir);
 
     println!("cargo:rustc-link-search=native={}", dst.display());
-    if cfg!(debug_assertions) {
-        println!("cargo:rustc-link-lib=static=mimalloc-debug");
-    } else {
-        println!("cargo:rustc-link-lib=static=mimalloc");
-    }
-}
-
-#[cfg(feature = "secure")]
-fn main() {
-    let mut dst = Config::new("c_src/mimalloc")
-        .define("SECURE", "ON")    
-        .build();
-
-    dst.push("build");
-    
-    println!("cargo:rustc-link-search=native={}", dst.display());
-    if cfg!(debug_assertions) {
-        println!("cargo:rustc-link-lib=static=mimalloc-debug");
-    } else {
-        println!("cargo:rustc-link-lib=static=mimalloc-secure");
-    }
+    println!("cargo:rustc-link-lib={}", out_name);
 }

--- a/libmimalloc-sys/src/lib.rs
+++ b/libmimalloc-sys/src/lib.rs
@@ -3,35 +3,35 @@
 use libc::{c_void, size_t};
 
 extern "C" {
-   pub fn mi_zalloc(size: size_t) -> *const c_void;
-   pub fn mi_malloc(size: size_t) -> *const c_void;
-   pub fn mi_realloc(p: *const c_void, size: size_t) -> *const c_void;
-   pub fn mi_zalloc_aligned(size: size_t, alignment: size_t) -> *const c_void;
-   pub fn mi_malloc_aligned(size: size_t, alignment: size_t) -> *const c_void;
-   pub fn mi_realloc_aligned(p: *const c_void, size: size_t, alignment: size_t) -> *const c_void;
-   pub fn mi_free(p: *const c_void) -> c_void;
+    pub fn mi_zalloc(size: size_t) -> *const c_void;
+    pub fn mi_malloc(size: size_t) -> *const c_void;
+    pub fn mi_realloc(p: *const c_void, size: size_t) -> *const c_void;
+    pub fn mi_zalloc_aligned(size: size_t, alignment: size_t) -> *const c_void;
+    pub fn mi_malloc_aligned(size: size_t, alignment: size_t) -> *const c_void;
+    pub fn mi_realloc_aligned(p: *const c_void, size: size_t, alignment: size_t) -> *const c_void;
+    pub fn mi_free(p: *const c_void) -> c_void;
 }
 
 #[cfg(test)]
 mod tests {
-   use super::*;
+    use super::*;
 
-   #[test]
-   fn it_frees_memory_malloc() {
-      let ptr = unsafe { mi_malloc_aligned(8, 8) } as *mut u8;
-      unsafe { mi_free(ptr as *const c_void) };
-   }
+    #[test]
+    fn it_frees_memory_malloc() {
+        let ptr = unsafe { mi_malloc_aligned(8, 8) } as *mut u8;
+        unsafe { mi_free(ptr as *const c_void) };
+    }
 
-   #[test]
-   fn it_frees_memory_zalloc() {
-      let ptr = unsafe { mi_zalloc_aligned(8, 8) } as *mut u8;
-      unsafe { mi_free(ptr as *const c_void) };
-   }
+    #[test]
+    fn it_frees_memory_zalloc() {
+        let ptr = unsafe { mi_zalloc_aligned(8, 8) } as *mut u8;
+        unsafe { mi_free(ptr as *const c_void) };
+    }
 
-   #[test]
-   fn it_frees_memory_realloc() {
-      let ptr = unsafe { mi_malloc_aligned(8, 8) } as *mut u8;
-      let ptr = unsafe { mi_realloc_aligned(ptr as *const c_void, 8, 8) } as *mut u8;
-      unsafe { mi_free(ptr as *const c_void) };
-   }
+    #[test]
+    fn it_frees_memory_realloc() {
+        let ptr = unsafe { mi_malloc_aligned(8, 8) } as *mut u8;
+        let ptr = unsafe { mi_realloc_aligned(ptr as *const c_void, 8, 8) } as *mut u8;
+        unsafe { mi_free(ptr as *const c_void) };
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! A drop-in global allocator wrapper around the [mimalloc](https://github.com/microsoft/mimalloc) allocator.
 //! Mimalloc is a general purpose, performance oriented allocator built by Microsoft.
-//! 
+//!
 //! ## Usage
 //! ```rust,ignore
 //! use mimalloc::MiMalloc;
@@ -12,11 +12,11 @@
 //! #[global_allocator]
 //! static GLOBAL: MiMalloc = MiMalloc;
 //! ```
-//! 
+//!
 //! ## Usage without secure mode
 //! By default this library builds mimalloc in secure mode. This means that
 //! heap allocations are encrypted, but this results in a 3% increase in overhead.
-//! 
+//!
 //! To disable secure mode, in `Cargo.toml`:
 //! ```rust,ignore
 //! [dependencies]
@@ -26,9 +26,8 @@
 extern crate libmimalloc_sys as ffi;
 
 use core::alloc::{GlobalAlloc, Layout};
-use core::ptr;
-use libc::c_void;
 use ffi::*;
+use libc::c_void;
 
 // Copied from https://github.com/rust-lang/rust/blob/master/src/libstd/sys_common/alloc.rs
 #[cfg(all(any(
@@ -52,7 +51,7 @@ const MIN_ALIGN: usize = 8;
 const MIN_ALIGN: usize = 16;
 
 /// Drop-in mimalloc global allocator.
-/// 
+///
 /// ## Usage
 /// ```rust,ignore
 /// use mimalloc::MiMalloc;
@@ -68,10 +67,9 @@ unsafe impl GlobalAlloc for MiMalloc {
         if layout.align() <= MIN_ALIGN && layout.align() <= layout.size() {
             mi_malloc(layout.size()) as *mut u8
         } else {
-            #[cfg(target_os = "macos")]
-            {
+            if cfg!(target_os = "macos") {
                 if layout.align() > (1 << 31) {
-                    return ptr::null_mut()
+                    return core::ptr::null_mut();
                 }
             }
 
@@ -84,17 +82,16 @@ unsafe impl GlobalAlloc for MiMalloc {
         if layout.align() <= MIN_ALIGN && layout.align() <= layout.size() {
             mi_zalloc(layout.size()) as *mut u8
         } else {
-            #[cfg(target_os = "macos")]
-            {
+            if cfg!(target_os = "macos") {
                 if layout.align() > (1 << 31) {
-                    return ptr::null_mut()
+                    return core::ptr::null_mut();
                 }
             }
 
             mi_zalloc_aligned(layout.size(), layout.align()) as *mut u8
         }
     }
-    
+
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
         mi_free(ptr as *const c_void);


### PR DESCRIPTION
Fix cmake build on windows.
Update to latest mimalloc commit.
Set "MI_OVERRIDE" to "OFF" (no need to build malloc/realloc/... symbols).
Set build target to "mimalloc-static" (no need to build shared or obj targets).
Small README changes.
