### PR TITLE
Optionally compile override feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ libmimalloc-sys = { path = "libmimalloc-sys", version = "0.1.15", default-featur
 [features]
 default = ["secure"]
 secure = ["libmimalloc-sys/secure"]
+override = ["libmimalloc-sys/override"]

--- a/libmimalloc-sys/Cargo.toml
+++ b/libmimalloc-sys/Cargo.toml
@@ -16,3 +16,4 @@ cmake = "0.1"
 
 [features]
 secure = []
+override = []

--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -63,7 +63,12 @@ fn get_cmake_build_type() -> Result<CMakeBuildType, String> {
 fn main() {
     let mut cfg = &mut Config::new("c_src/mimalloc");
 
-    cfg = cfg.define("MI_OVERRIDE", "OFF");
+    if cfg!(feature = "override") {
+        cfg = cfg.define("MI_OVERRIDE", "ON");
+    } else {
+        cfg = cfg.define("MI_OVERRIDE", "OFF");
+    }
+
     cfg = cfg.define("MI_BUILD_TESTS", "OFF");
 
     if cfg!(feature = "secure") {


### PR DESCRIPTION
I have found it very useful to set `MI_OVERRIDE=ON` when C/C++ code is used by Rust applications/libraries. This PR adds a feature to optionally enable this flag (default is false)