### PR TITLE
Don't return a c_void by value from mi_free

### DIFF
--- a/libmimalloc-sys/src/lib.rs
+++ b/libmimalloc-sys/src/lib.rs
@@ -9,7 +9,7 @@ extern "C" {
     pub fn mi_zalloc_aligned(size: usize, alignment: usize) -> *mut c_void;
     pub fn mi_malloc_aligned(size: usize, alignment: usize) -> *mut c_void;
     pub fn mi_realloc_aligned(p: *mut c_void, size: usize, alignment: usize) -> *mut c_void;
-    pub fn mi_free(p: *mut c_void) -> c_void;
+    pub fn mi_free(p: *mut c_void);
     pub fn mi_usable_size(p: *mut c_void) -> usize;
 }
 


### PR DESCRIPTION
This was undefined behavior since the signature was wrong, but in practice it's probably fine, unless someone actually uses the c_void.

At least, on ABIs I'm familiar with that's true, and it's hard to imagine ones where a u8 (what [c_void boils down to](https://doc.rust-lang.org/src/core/ffi.rs.html#35)) isn't returned by register.

Also it was unsafe to call this, anyway -- so callers doing that could be assumed to know better than to use the returned `c_void` for anything.

Fixes #26