### PR TITLE
Fix clippy, improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  # Run daily to catch when Rust updates cause problems to happen.
+  schedule:
+    - cron: '00 01 * * *'
 
 jobs:
   rust:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: --workspace -- -D warnings

--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::collapsible_if)]
 use cmake::Config;
 use std::env;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,10 +67,8 @@ unsafe impl GlobalAlloc for MiMalloc {
         if layout.align() <= MIN_ALIGN && layout.align() <= layout.size() {
             mi_malloc(layout.size()) as *mut u8
         } else {
-            if cfg!(target_os = "macos") {
-                if layout.align() > (1 << 31) {
-                    return core::ptr::null_mut();
-                }
+            if cfg!(target_os = "macos") && layout.align() > (1 << 31) {
+                return core::ptr::null_mut();
             }
 
             mi_malloc_aligned(layout.size(), layout.align()) as *mut u8
@@ -82,10 +80,8 @@ unsafe impl GlobalAlloc for MiMalloc {
         if layout.align() <= MIN_ALIGN && layout.align() <= layout.size() {
             mi_zalloc(layout.size()) as *mut u8
         } else {
-            if cfg!(target_os = "macos") {
-                if layout.align() > (1 << 31) {
-                    return core::ptr::null_mut();
-                }
+            if cfg!(target_os = "macos") && layout.align() > (1 << 31) {
+                return core::ptr::null_mut();
             }
 
             mi_zalloc_aligned(layout.size(), layout.align()) as *mut u8
@@ -117,7 +113,7 @@ mod tests {
             let layout = Layout::from_size_align(8, 8).unwrap();
             let alloc = MiMalloc;
 
-            let ptr = alloc.alloc(layout.clone());
+            let ptr = alloc.alloc(layout);
             alloc.dealloc(ptr, layout);
         }
     }
@@ -128,7 +124,7 @@ mod tests {
             let layout = Layout::from_size_align(8, 8).unwrap();
             let alloc = MiMalloc;
 
-            let ptr = alloc.alloc_zeroed(layout.clone());
+            let ptr = alloc.alloc_zeroed(layout);
             alloc.dealloc(ptr, layout);
         }
     }
@@ -139,8 +135,8 @@ mod tests {
             let layout = Layout::from_size_align(8, 8).unwrap();
             let alloc = MiMalloc;
 
-            let ptr = alloc.alloc(layout.clone());
-            let ptr = alloc.realloc(ptr, layout.clone(), 16);
+            let ptr = alloc.alloc(layout);
+            let ptr = alloc.realloc(ptr, layout, 16);
             alloc.dealloc(ptr, layout);
         }
     }


### PR DESCRIPTION
This:

1. Fixes the CI warnings that I see in #29 
2. Upgrade clippy's warnings to errors. (I'm assuming this is what you wanted, and it's just a bug that you don't have it set up that way, but I'm totally happy to undo this if you'd rather keep clippy as warning-only).
3. Run CI on a schedule so that if Rust updates and causes e.g. clippy or rustfmt problems, you get a notice.

Number 3 means if it starts failing, you get emails until it's fixed, but this avoids forcing contributors to touch/fix parts unrelated to their contribution, or having a busted master. (Personally, this has worked well for me, but maybe if you had a lot of crates it could start being a problem). All that said, I would not fault you if you don't more emails in your life.

Edit: Embarrassingly forgot to rename the PR title, whoops!