### PR TITLE
Expose most of mimalloc API from libmimalloc-sys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
           command: test
           args: --no-default-features
 
+      - name: Test libmimalloc-sys crate bindings.
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: -p libmimalloc-sys-test
+
   lint:
     name: Rustfmt / Clippy
     runs-on: ubuntu-latest
@@ -84,3 +90,36 @@ jobs:
         with:
           command: clippy
           args: --workspace -- -D warnings
+
+  # Detect cases where documentation links would be dead
+  doc:
+    name: Check documentation
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      # Note: We need to use nightly rust, and `cargo rustdoc` (yes, not `cargo
+      # doc`) to actually get it to respect -D warnings... Using nightly also
+      # gets us the nicer syntax for linking to functions, and is in-line with
+      # what docs.rs uses.
+
+      - name: 'Check documentation links in `mimalloc`'
+        uses: actions-rs/cargo@v1
+        with:
+          command: rustdoc
+          args: -- -D warnings
+
+      - name: 'Check documentation links in `libmimalloc-sys`'
+        uses: actions-rs/cargo@v1
+        with:
+          command: rustdoc
+          args: -p libmimalloc-sys -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 readme = "README.md"
 
 [workspace]
-members = ["libmimalloc-sys"]
+members = ["libmimalloc-sys", "libmimalloc-sys/sys-test"]
 
 [badges]
 travis-ci = { repository = "purpleprotocol/mimalloc_rust" }

--- a/libmimalloc-sys/Cargo.toml
+++ b/libmimalloc-sys/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 links = "mimalloc"
 
 [dependencies]
+cty = { version = "0.2", optional = true }
 
 [build-dependencies]
 cmake = "0.1"
@@ -18,3 +19,8 @@ cmake = "0.1"
 [features]
 secure = []
 override = []
+extended = ["cty"]
+
+# Show `extended` on docs.rs since it's the full API surface.
+[package.metadata.docs.rs]
+features = ["extended"]

--- a/libmimalloc-sys/src/extended.rs
+++ b/libmimalloc-sys/src/extended.rs
@@ -1,0 +1,698 @@
+#![allow(nonstandard_style)]
+
+use core::ffi::c_void;
+
+use cty::{c_char, c_int, c_long, c_ulonglong};
+
+/// The maximum number of bytes which may be used as an argument to a function
+/// in the `_small` family ([`mi_malloc_small`], [`mi_zalloc_small`], etc).
+pub const MI_SMALL_SIZE_MAX: usize = 128 * core::mem::size_of::<*mut c_void>();
+
+extern "C" {
+    /// Allocate `count` items of `size` length each.
+    ///
+    /// Returns `null` if `count * size` overflows or on out-of-memory.
+    ///
+    /// All items are initialized to zero.
+    pub fn mi_calloc(count: usize, size: usize) -> *mut c_void;
+
+    /// Allocate `count` items of `size` length each.
+    ///
+    /// Returns `null` if `count * size` overflows or on out-of-memory,
+    /// otherwise returns the same as [`mi_malloc(count *
+    /// size)`](crate::mi_malloc).
+    /// Equivalent to [`mi_calloc`], but returns uninitialized (and not zeroed)
+    /// bytes.
+    pub fn mi_mallocn(count: usize, size: usize) -> *mut c_void;
+
+    /// Re-allocate memory to `count` elements of `size` bytes.
+    ///
+    /// The realloc equivalent of the [`mi_mallocn`] interface. Returns `null`
+    /// if `count * size` overflows or on out-of-memory, otherwise returns the
+    /// same as [`mi_realloc(p, count * size)`](crate::mi_realloc).
+    pub fn mi_reallocn(p: *mut c_void, count: usize, size: usize) -> *mut c_void;
+
+    /// Try to re-allocate memory to `newsize` bytes _in place_.
+    ///
+    /// Returns null on out-of-memory or if the memory could not be expanded in
+    /// place. On success, returns the same pointer as `p`.
+    ///
+    /// If `newsize` is larger than the original `size` allocated for `p`, the
+    /// bytes after `size` are uninitialized.
+    ///
+    /// If null is returned, the original pointer is not freed.
+    ///
+    /// Note: Conceptually, this is a realloc-like which returns null if it
+    /// would be forced to reallocate memory and copy. In practice it's
+    /// equivalent testing against [`mi_usable_size`](crate::mi_usable_size).
+    pub fn mi_expand(p: *mut c_void, newsize: usize) -> *mut c_void;
+
+    /// Re-allocate memory to `newsize` bytes.
+    ///
+    /// This differs from [`mi_realloc`](crate::mi_realloc) in that on failure,
+    /// `p` is freed.
+    pub fn mi_reallocf(p: *mut c_void, newsize: usize) -> *mut c_void;
+
+    /// Allocate and duplicate a nul-terminated C string.
+    ///
+    /// This can be useful for Rust code when interacting with the FFI.
+    pub fn mi_strdup(s: *const c_char) -> *mut c_char;
+
+    /// Allocate and duplicate a nul-terminated C string, up to `n` bytes.
+    ///
+    /// This can be useful for Rust code when interacting with the FFI.
+    pub fn mi_strndup(s: *const c_char, n: usize) -> *mut c_char;
+
+    /// Resolve a file path name, producing a `C` string which can be passed to
+    /// [`mi_free`](crate::mi_free).
+    ///
+    /// `resolved_name` should be null, but can also point to a buffer of at
+    /// least `PATH_MAX` bytes.
+    ///
+    /// If successful, returns a pointer to the resolved absolute file name, or
+    /// `null` on failure (with `errno` set to the error code).
+    ///
+    /// If `resolved_name` was `null`, the returned result should be freed with
+    /// [`mi_free`](crate::mi_free).
+    ///
+    /// This can rarely be useful in FFI code, but is mostly included for
+    /// completeness.
+    pub fn mi_realpath(fname: *const c_char, resolved_name: *mut c_char) -> *mut c_char;
+
+    /// Allocate `size * count` bytes aligned by `alignment`.
+    ///
+    /// Return pointer to the allocated memory or null if out of memory or if
+    /// `size * count` overflows.
+    ///
+    /// Returns a unique pointer if called with `size * count` 0.
+    pub fn mi_calloc_aligned(count: usize, size: usize, alignment: usize) -> *mut c_void;
+
+    /// Allocate `size` bytes aligned by `alignment` at a specified `offset`.
+    ///
+    /// Note that the resulting pointer itself is not aligned by the alignment,
+    /// but after `offset` bytes it will be. This can be useful for allocating
+    /// data with an inline header, where the data has a specific alignment
+    /// requirement.
+    ///
+    /// Specifically, if `p` is the returned pointer `p.add(offset)` is aligned
+    /// to `alignment`.
+    pub fn mi_malloc_aligned_at(size: usize, alignment: usize, offset: usize) -> *mut c_void;
+
+    /// Allocate `size` bytes aligned by `alignment` at a specified `offset`,
+    /// zero-initialized.
+    ///
+    /// This is a [`mi_zalloc`](crate::mi_zalloc) equivalent of [`mi_malloc_aligned_at`].
+    pub fn mi_zalloc_aligned_at(size: usize, alignment: usize, offset: usize) -> *mut c_void;
+
+    /// Allocate `size * count` bytes aligned by `alignment` at a specified
+    /// `offset`, zero-initialized.
+    ///
+    /// This is a [`calloc`](crate::mi_calloc) equivalent of [`mi_malloc_aligned_at`].
+    pub fn mi_calloc_aligned_at(
+        count: usize,
+        size: usize,
+        alignment: usize,
+        offset: usize,
+    ) -> *mut c_void;
+
+    /// Re-allocate memory to `newsize` bytes aligned by `alignment` at a
+    /// specified `offset`.
+    ///
+    /// This is a [`realloc`](crate::mi_realloc) equivalent of [`mi_malloc_aligned_at`].
+    pub fn mi_realloc_aligned_at(
+        p: *mut c_void,
+        newsize: usize,
+        alignment: usize,
+        offset: usize,
+    ) -> *mut c_void;
+
+    /// Allocate an object of no more than [`MI_SMALL_SIZE_MAX`] bytes.
+    ///
+    /// Does not check that `size` is indeed small.
+    ///
+    /// Note: Currently [`mi_malloc`](crate::mi_malloc) checks if `size` is
+    /// small and calls this if
+    /// so at runtime, so its' only worth using if you know for certain.
+    pub fn mi_malloc_small(size: usize) -> *mut c_void;
+
+    /// Allocate an zero-initialized object of no more than
+    /// [`MI_SMALL_SIZE_MAX`] bytes.
+    ///
+    /// Does not check that `size` is indeed small.
+    ///
+    /// Note: Currently [`mi_zalloc`](crate::mi_zalloc) checks if `size` is
+    /// small and calls this if so at runtime, so its' only worth using if you
+    /// know for certain.
+    pub fn mi_zalloc_small(size: usize) -> *mut c_void;
+
+    /// Return the used allocation size.
+    ///
+    /// Returns the size `n` that will be allocated, where `n >= size`.
+    ///
+    /// Generally, `mi_usable_size(mi_malloc(size)) == mi_good_size(size)`. This
+    /// can be used to reduce internal wasted space when allocating buffers for
+    /// example.
+    ///
+    /// See [`mi_usable_size`](crate::mi_usable_size).
+    pub fn mi_good_size(size: usize) -> usize;
+
+    /// Eagerly free memory.
+    ///
+    /// If `force` is true, aggressively return memory to the OS (can be
+    /// expensive!)
+    ///
+    /// Regular code should not have to call this function. It can be beneficial
+    /// in very narrow circumstances; in particular, when a long running thread
+    /// allocates a lot of blocks that are freed by other threads it may improve
+    /// resource usage by calling this every once in a while.
+    pub fn mi_collect(force: bool);
+
+    /// Print the main statistics.
+    ///
+    /// Ignores the passed in argument, and outputs to the registered output
+    /// function or stderr by default.
+    ///
+    /// Most detailed when using a debug build.
+    pub fn mi_stats_print(_: *const c_void);
+
+    /// Print the main statistics.
+    ///
+    /// Pass `None` for `out` to use the default. If `out` is provided, `arc` is
+    /// passed as it's second parameter.
+    ///
+    /// Most detailed when using a debug build.
+    pub fn mi_stats_print_out(out: Option<mi_output_fun>, arg: *mut c_void);
+
+    /// Reset statistics.
+    ///
+    /// Note: This function is thread safe.
+    pub fn mi_stats_reset();
+
+    /// Merge thread local statistics with the main statistics and reset.
+    ///
+    /// Note: This function is thread safe.
+    pub fn mi_stats_merge();
+
+    /// Initialize mimalloc on a thread.
+    ///
+    /// Should not be used as on most systems (pthreads, windows) this is done
+    /// automatically.
+    pub fn mi_thread_init();
+
+    /// Uninitialize mimalloc on a thread.
+    ///
+    /// Should not be used as on most systems (pthreads, windows) this is done
+    /// automatically. Ensures that any memory that is not freed yet (but will
+    /// be freed by other threads in the future) is properly handled.
+    ///
+    /// Note: This function is thread safe.
+    pub fn mi_thread_done();
+
+    /// Print out heap statistics for this thread.
+    ///
+    /// Pass `None` for `out` to use the default. If `out` is provided, `arc` is
+    /// passed as it's second parameter
+    ///
+    /// Most detailed when using a debug build.
+    ///
+    /// Note: This function is thread safe.
+    pub fn mi_thread_stats_print_out(out: Option<mi_output_fun>, arg: *mut c_void);
+
+    /// Register an output function.
+    ///
+    /// - `out` The output function, use `None` to output to stderr.
+    /// - `arg` Argument that will be passed on to the output function.
+    ///
+    /// The `out` function is called to output any information from mimalloc,
+    /// like verbose or warning messages.
+    ///
+    /// Note: This function is thread safe.
+    pub fn mi_register_output(out: Option<mi_output_fun>, arg: *mut c_void);
+
+    /// Register a deferred free function.
+    ///
+    /// - `deferred_free` Address of a deferred free-ing function or `None` to
+    ///   unregister.
+    /// - `arg` Argument that will be passed on to the deferred free function.
+    ///
+    /// Some runtime systems use deferred free-ing, for example when using
+    /// reference counting to limit the worst case free time.
+    ///
+    /// Such systems can register (re-entrant) deferred free function to free
+    /// more memory on demand.
+    ///
+    /// - When the `force` parameter is `true` all possible memory should be
+    ///   freed.
+    ///
+    /// - The per-thread `heartbeat` parameter is monotonically increasing and
+    ///   guaranteed to be deterministic if the program allocates
+    ///   deterministically.
+    ///
+    /// - The `deferred_free` function is guaranteed to be called
+    ///   deterministically after some number of allocations (regardless of
+    ///   freeing or available free memory).
+    ///
+    /// At most one `deferred_free` function can be active.
+    ///
+    /// Note: This function is thread safe.
+    pub fn mi_register_deferred_free(out: Option<mi_deferred_free_fun>, arg: *mut c_void);
+
+    /// Register an error callback function.
+    ///
+    /// The `errfun` function is called on an error in mimalloc after emitting
+    /// an error message (through the output function).
+    ///
+    /// It as always legal to just return from the `errfun` function in which
+    /// case allocation functions generally return null or ignore the condition.
+    ///
+    /// The default function only calls abort() when compiled in secure mode
+    /// with an `EFAULT` error. The possible error codes are:
+    ///
+    /// - `EAGAIN` (11): Double free was detected (only in debug and secure
+    ///   mode).
+    /// - `EFAULT` (14): Corrupted free list or meta-data was detected (only in
+    ///   debug and secure mode).
+    /// - `ENOMEM` (12): Not enough memory available to satisfy the request.
+    /// - `EOVERFLOW` (75): Too large a request, for example in `mi_calloc`, the
+    ///   `count` and `size` parameters are too large.
+    /// - `EINVAL` (22): Trying to free or re-allocate an invalid pointer.
+    ///
+    /// Note: This function is thread safe.
+    pub fn mi_register_error(out: Option<mi_error_fun>, arg: *mut c_void);
+}
+
+/// An output callback. Must be thread-safe.
+///
+/// See [`mi_stats_print_out`], [`mi_thread_stats_print_out`], [`mi_register_output`]
+pub type mi_output_fun = unsafe extern "C" fn(msg: *const c_char, arg: *mut c_void);
+
+/// Type of deferred free functions. Must be thread-safe.
+///
+/// - `force`: If true, all outstanding items should be freed.
+/// - `heartbeat` A monotonically increasing count.
+/// - `arg` Argument that was passed at registration to hold extra state.
+///
+/// See [`mi_register_deferred_free`]
+pub type mi_deferred_free_fun =
+    unsafe extern "C" fn(force: bool, heartbeat: c_ulonglong, arg: *mut c_void);
+
+/// Type of error callback functions. Must be thread-safe.
+///
+/// - `err`: Error code (see [`mi_register_error`] for a list).
+/// - `arg`: Argument that was passed at registration to hold extra state.
+///
+/// See [`mi_register_error`]
+pub type mi_error_fun = unsafe extern "C" fn(code: c_int, arg: *mut c_void);
+
+/// Runtime options. Only exists to make ctest happy since this was defined as
+/// `typedef enum mi_option_e { ... } mi_option_t;`...
+#[doc(hidden)]
+pub type mi_option_e = c_int;
+
+/// Runtime options. All options are false by default.
+///
+/// Note: Currently experimental options (values > `mi_option_verbose` are not
+/// given named constants), as they may change and make exposing a stable API
+/// difficult.
+pub type mi_option_t = mi_option_e;
+
+// Note: mimalloc doc website seems to have the order of show_stats and
+// show_errors reversed as of 1.6.3, however what I have here is correct:
+// https://github.com/microsoft/mimalloc/issues/266#issuecomment-653822341
+
+/// Option allowing printing error messages to stderr.
+pub const mi_option_show_errors: mi_option_t = 0;
+
+/// Option allowing printing statistics to stderr when the program is done.
+pub const mi_option_show_stats: mi_option_t = 1;
+
+/// Option allowing printing verbose messages to stderr.
+pub const mi_option_verbose: mi_option_t = 2;
+
+extern "C" {
+    // Note: mi_option_{enable,disable} aren't exposed because they're redundant
+    // and because of https://github.com/microsoft/mimalloc/issues/266.
+
+    /// Returns true if the provided option is enabled.
+    ///
+    /// Note: this function is not thread safe.
+    pub fn mi_option_enabled(option: mi_option_t) -> bool;
+
+    /// Enable or disable the given option.
+    ///
+    /// Note: this function is not thread safe.
+    pub fn mi_option_set_enabled(option: mi_option_t, enable: bool);
+
+    /// If the given option has not yet been initialized with [`mi_option_set`]
+    /// or [`mi_option_set_enabled`], enables or disables the option. If it has,
+    /// this function does nothing.
+    ///
+    /// Note: this function is not thread safe.
+    pub fn mi_option_set_enabled_default(option: mi_option_t, enable: bool);
+
+    /// Returns the value of the provided option.
+    ///
+    /// The value of boolean options is 1 or 0, however experimental options
+    /// exist which take a numeric value, which is the intended use of this
+    /// function.
+    ///
+    /// These options are not exposed as constants for stability reasons,
+    /// however you can still use them as arguments to this and other
+    /// `mi_option_` functions if needed, see the mimalloc documentation for
+    /// details: https://microsoft.github.io/mimalloc/group__options.html
+    ///
+    /// Note: this function is not thread safe.
+    pub fn mi_option_get(option: mi_option_t) -> c_long;
+
+    /// Set the option to the given value.
+    ///
+    /// The value of boolean options is 1 or 0, however experimental options
+    /// exist which take a numeric value, which is the intended use of this
+    /// function.
+    ///
+    /// These options are not exposed as constants for stability reasons,
+    /// however you can still use them as arguments to this and other
+    /// `mi_option_` functions if needed,
+    ///
+    /// Note: this function is not thread safe.
+    pub fn mi_option_set(option: mi_option_t, value: c_long);
+
+    /// If the given option has not yet been initialized with [`mi_option_set`]
+    /// or [`mi_option_set_enabled`], sets the option to the given value. If it
+    /// has, this function does nothing.
+    ///
+    /// The value of boolean options is 1 or 0, however experimental options
+    /// exist which take a numeric value, which is the intended use of this
+    /// function.
+    ///
+    /// These options are not exposed as constants for stability reasons,
+    /// however you can still use them as arguments to this and other
+    /// `mi_option_` functions if needed.
+    ///
+    /// Note: this function is not thread safe.
+    pub fn mi_option_set_default(option: mi_option_t, value: c_long);
+
+}
+
+#[doc(hidden)]
+pub type mi_heap_s = mi_heap_t;
+#[doc(hidden)]
+pub type mi_heap_area_s = mi_heap_area_t;
+
+/// First-class heaps that can be destroyed in one go.
+///
+/// Note: The pointers allocated out of a heap can be be freed using
+/// [`mi_free`](crate::mi_free) -- there is no `mi_heap_free`.
+///
+/// # Example
+///
+/// ```
+/// use libmimalloc_sys as mi;
+/// unsafe {
+///     let h = mi::mi_heap_new();
+///     assert!(!h.is_null());
+///     let p = mi::mi_heap_malloc(h, 50);
+///     assert!(!p.is_null());
+///
+///     // use p...
+///     mi::mi_free(p);
+///
+///     // Clean up the heap. Note that pointers allocated from `h`
+///     // are *not* invalided by `mi_heap_delete`. You would have
+///     // to use (the very dangerous) `mi_heap_destroy` for that
+///     // behavior
+///     mi::mi_heap_delete(h);
+/// }
+/// ```
+#[repr(C)]
+pub struct mi_heap_t {
+    _priv: [u8; 0],
+}
+
+/// An area of heap space contains blocks of a single size.
+///
+/// The bytes in freed blocks are `committed - used`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct mi_heap_area_t {
+    /// Start of the area containing heap blocks.
+    pub blocks: *mut c_void,
+    /// Bytes reserved for this area.
+    pub reserved: usize,
+    /// Current committed bytes of this area.
+    pub committed: usize,
+    /// Bytes in use by allocated blocks.
+    pub used: usize,
+    /// Size in bytes of one block.
+    pub block_size: usize,
+}
+
+// Provide a default impl so that the `non_exhaustive` bound is not too painful.
+impl Default for mi_heap_area_t {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            blocks: core::ptr::null_mut(),
+            reserved: 0,
+            committed: 0,
+            used: 0,
+            block_size: 0,
+        }
+    }
+}
+
+/// Visitor function passed to [`mi_heap_visit_blocks`]
+///
+/// Should return `true` to continue, and `false` to stop visiting (i.e. break)
+///
+/// This function is always first called for every `area` with `block` as a null
+/// pointer. If `visit_all_blocks` was `true`, the function is then called for
+/// every allocated block in that area.
+pub type mi_block_visit_fun = unsafe extern "C" fn(
+    heap: *const mi_heap_t,
+    area: *const mi_heap_area_t,
+    block: *mut c_void,
+    block_size: usize,
+    arg: *mut c_void,
+) -> bool;
+
+extern "C" {
+    /// Create a new heap that can be used for allocation.
+    pub fn mi_heap_new() -> *mut mi_heap_t;
+
+    /// Delete a previously allocated heap.
+    ///
+    /// This will release resources and migrate any still allocated blocks in
+    /// this heap (efficienty) to the default heap.
+    ///
+    /// If `heap` is the default heap, the default heap is set to the backing
+    /// heap.
+    pub fn mi_heap_delete(heap: *mut mi_heap_t);
+
+    /// Destroy a heap, freeing all its still allocated blocks.
+    ///
+    /// Use with care as this will free all blocks still allocated in the heap.
+    /// However, this can be a very efficient way to free all heap memory in one
+    /// go.
+    ///
+    /// If `heap` is the default heap, the default heap is set to the backing
+    /// heap.
+    pub fn mi_heap_destroy(heap: *mut mi_heap_t);
+
+    /// Set the default heap to use for [`mi_malloc`](crate::mi_malloc) et al.
+    ///
+    /// Returns the previous default heap.
+    pub fn mi_heap_set_default(heap: *mut mi_heap_t) -> *mut mi_heap_t;
+
+    /// Get the default heap that is used for [`mi_malloc`](crate::mi_malloc) et al.
+    pub fn mi_heap_get_default() -> *mut mi_heap_t;
+
+    /// Get the backing heap.
+    ///
+    /// The _backing_ heap is the initial default heap for a thread and always
+    /// available for allocations. It cannot be destroyed or deleted except by
+    /// exiting the thread.
+    pub fn mi_heap_get_backing() -> *mut mi_heap_t;
+
+    /// Release outstanding resources in a specific heap.
+    ///
+    /// Similar to to [`mi_collect`], but takes the heap to collect as an argument.
+    pub fn mi_heap_collect(heap: *mut mi_heap_t, force: bool);
+
+    /// Equivalent to [`mi_malloc`](crate::mi_malloc), but allocates out of the
+    /// specific heap instead of the default.
+    pub fn mi_heap_malloc(heap: *mut mi_heap_t, size: usize) -> *mut c_void;
+
+    /// Equivalent to [`mi_zalloc`](crate::mi_zalloc), but allocates out of the
+    /// specific heap instead of the default.
+    pub fn mi_heap_zalloc(heap: *mut mi_heap_t, size: usize) -> *mut c_void;
+
+    /// Equivalent to [`mi_calloc`], but allocates out of the specific heap
+    /// instead of the default.
+    pub fn mi_heap_calloc(heap: *mut mi_heap_t, count: usize, size: usize) -> *mut c_void;
+
+    /// Equivalent to [`mi_mallocn`], but allocates out of the specific heap
+    /// instead of the default.
+    pub fn mi_heap_mallocn(heap: *mut mi_heap_t, count: usize, size: usize) -> *mut c_void;
+
+    /// Equivalent to [`mi_malloc_small`], but allocates out of the specific
+    /// heap instead of the default.
+    ///
+    /// `size` must be smaller or equal to [`MI_SMALL_SIZE_MAX`].
+    pub fn mi_heap_malloc_small(heap: *mut mi_heap_t, size: usize) -> *mut c_void;
+
+    /// Equivalent to [`mi_realloc`](crate::mi_realloc), but allocates out of
+    /// the specific heap instead of the default.
+    pub fn mi_heap_realloc(heap: *mut mi_heap_t, p: *mut c_void, newsize: usize) -> *mut c_void;
+
+    /// Equivalent to [`mi_reallocn`], but allocates out of the specific heap
+    /// instead of the default.
+    pub fn mi_heap_reallocn(
+        heap: *mut mi_heap_t,
+        p: *mut c_void,
+        count: usize,
+        size: usize,
+    ) -> *mut c_void;
+
+    /// Equivalent to [`mi_reallocf`], but allocates out of the specific heap
+    /// instead of the default.
+    pub fn mi_heap_reallocf(heap: *mut mi_heap_t, p: *mut c_void, newsize: usize) -> *mut c_void;
+
+    /// Equivalent to [`mi_strdup`], but allocates out of the specific heap
+    /// instead of the default.
+    pub fn mi_heap_strdup(heap: *mut mi_heap_t, s: *const c_char) -> *mut c_char;
+
+    /// Equivalent to [`mi_strndup`], but allocates out of the specific heap
+    /// instead of the default.
+    pub fn mi_heap_strndup(heap: *mut mi_heap_t, s: *const c_char, n: usize) -> *mut c_char;
+
+    /// Equivalent to [`mi_realpath`], but allocates out of the specific heap
+    /// instead of the default.
+    pub fn mi_heap_realpath(
+        heap: *mut mi_heap_t,
+        fname: *const c_char,
+        resolved_name: *mut c_char,
+    ) -> *mut c_char;
+
+    /// Equivalent to [`mi_malloc_aligned`](crate::mi_malloc_aligned), but
+    /// allocates out of the specific heap instead of the default.
+    pub fn mi_heap_malloc_aligned(
+        heap: *mut mi_heap_t,
+        size: usize,
+        alignment: usize,
+    ) -> *mut c_void;
+
+    /// Equivalent to [`mi_malloc_aligned_at`], but allocates out of the
+    /// specific heap instead of the default.
+    pub fn mi_heap_malloc_aligned_at(
+        heap: *mut mi_heap_t,
+        size: usize,
+        alignment: usize,
+        offset: usize,
+    ) -> *mut c_void;
+
+    /// Equivalent to [`mi_zalloc_aligned`](crate::mi_zalloc_aligned), but
+    /// allocates out of the specific heap instead of the default.
+    pub fn mi_heap_zalloc_aligned(
+        heap: *mut mi_heap_t,
+        size: usize,
+        alignment: usize,
+    ) -> *mut c_void;
+
+    /// Equivalent to [`mi_zalloc_aligned_at`], but allocates out of the
+    /// specific heap instead of the default.
+    pub fn mi_heap_zalloc_aligned_at(
+        heap: *mut mi_heap_t,
+        size: usize,
+        alignment: usize,
+        offset: usize,
+    ) -> *mut c_void;
+
+    /// Equivalent to [`mi_calloc_aligned`], but allocates out of the specific
+    /// heap instead of the default.
+    pub fn mi_heap_calloc_aligned(
+        heap: *mut mi_heap_t,
+        count: usize,
+        size: usize,
+        alignment: usize,
+    ) -> *mut c_void;
+
+    /// Equivalent to [`mi_calloc_aligned_at`], but allocates out of the
+    /// specific heap instead of the default.
+    pub fn mi_heap_calloc_aligned_at(
+        heap: *mut mi_heap_t,
+        count: usize,
+        size: usize,
+        alignment: usize,
+        offset: usize,
+    ) -> *mut c_void;
+
+    /// Equivalent to [`mi_realloc_aligned`](crate::mi_realloc_aligned), but allocates out of the specific
+    /// heap instead of the default.
+    pub fn mi_heap_realloc_aligned(
+        heap: *mut mi_heap_t,
+        p: *mut c_void,
+        newsize: usize,
+        alignment: usize,
+    ) -> *mut c_void;
+
+    /// Equivalent to [`mi_realloc_aligned_at`], but allocates out of the
+    /// specific heap instead of the default.
+    pub fn mi_heap_realloc_aligned_at(
+        heap: *mut mi_heap_t,
+        p: *mut c_void,
+        newsize: usize,
+        alignment: usize,
+        offset: usize,
+    ) -> *mut c_void;
+
+    /// Does a heap contain a pointer to a previously allocated block?
+    ///
+    /// `p` must be a pointer to a previously allocated block (in any heap) -- it cannot be some
+    /// random pointer!
+    ///
+    /// Returns `true` if the block pointed to by `p` is in the `heap`.
+    ///
+    /// See [`mi_heap_check_owned`].
+    pub fn mi_heap_contains_block(heap: *mut mi_heap_t, p: *const c_void) -> bool;
+
+    /// Check safely if any pointer is part of a heap.
+    ///
+    /// `p` may be any pointer -- not required to be previously allocated by the
+    /// given heap or any other mimalloc heap. Returns `true` if `p` points to a
+    /// block in the given heap, false otherwise.
+    ///
+    /// Note: expensive function, linear in the pages in the heap.
+    ///
+    /// See [`mi_heap_contains_block`], [`mi_heap_get_default`]
+    pub fn mi_heap_check_owned(heap: *mut mi_heap_t, p: *const c_void) -> bool;
+
+    /// Check safely if any pointer is part of the default heap of this thread.
+    ///
+    /// `p` may be any pointer -- not required to be previously allocated by the
+    /// default heap for this thread, or any other mimalloc heap. Returns `true`
+    /// if `p` points to a block in the default heap, false otherwise.
+    ///
+    /// Note: expensive function, linear in the pages in the heap.
+    ///
+    /// See [`mi_heap_contains_block`], [`mi_heap_get_default`]
+    pub fn mi_check_owned(p: *const c_void) -> bool;
+
+    /// Visit all areas and blocks in `heap`.
+    ///
+    /// If `visit_all_blocks` is false, the `visitor` is only called once for
+    /// every heap area. If it's true, the `visitor` is also called for every
+    /// allocated block inside every area (with `!block.is_null()`). Return
+    /// `false` from the `visitor` to return early.
+    ///
+    /// `arg` is an extra argument passed into the `visitor`.
+    ///
+    /// Returns `true` if all areas and blocks were visited.
+    pub fn mi_heap_visit_blocks(
+        heap: *const mi_heap_t,
+        visit_all_blocks: bool,
+        visitor: mi_block_visit_fun,
+        arg: *mut c_void,
+    ) -> bool;
+}

--- a/libmimalloc-sys/src/lib.rs
+++ b/libmimalloc-sys/src/lib.rs
@@ -3,13 +3,64 @@
 use core::ffi::c_void;
 
 extern "C" {
+    /// Allocate zero-initialized `size` bytes.
+    ///
+    /// Returns a pointer to newly allocated zero-initialized memory, or null if
+    /// out of memory.
     pub fn mi_zalloc(size: usize) -> *mut c_void;
+
+    /// Allocate `size` bytes.
+    ///
+    /// Returns pointer to the allocated memory or null if out of memory.
+    /// Returns a unique pointer if called with `size` 0.
     pub fn mi_malloc(size: usize) -> *mut c_void;
-    pub fn mi_realloc(p: *mut c_void, size: usize) -> *mut c_void;
+
+    /// Re-allocate memory to `newsize` bytes.
+    ///
+    /// Return pointer to the allocated memory or null if out of memory. If null
+    /// is returned, the pointer `p` is not freed. Otherwise the original
+    /// pointer is either freed or returned as the reallocated result (in case
+    /// it fits in-place with the new size).
+    ///
+    /// If `p` is null, it behaves as [`mi_malloc`]. If `newsize` is larger than
+    /// the original `size` allocated for `p`, the bytes after `size` are
+    /// uninitialized.
+    pub fn mi_realloc(p: *mut c_void, newsize: usize) -> *mut c_void;
+
+    /// Allocate `size` bytes aligned by `alignment`, initialized to zero.
+    ///
+    /// Return pointer to the allocated memory or null if out of memory.
+    ///
+    /// Returns a unique pointer if called with `size` 0.
     pub fn mi_zalloc_aligned(size: usize, alignment: usize) -> *mut c_void;
+
+    /// Allocate `size` bytes aligned by `alignment`.
+    ///
+    /// Return pointer to the allocated memory or null if out of memory.
+    ///
+    /// Returns a unique pointer if called with `size` 0.
     pub fn mi_malloc_aligned(size: usize, alignment: usize) -> *mut c_void;
-    pub fn mi_realloc_aligned(p: *mut c_void, size: usize, alignment: usize) -> *mut c_void;
+
+    /// Re-allocate memory to `newsize` bytes, aligned by `alignment`.
+    ///
+    /// Return pointer to the allocated memory or null if out of memory. If null
+    /// is returned, the pointer `p` is not freed. Otherwise the original
+    /// pointer is either freed or returned as the reallocated result (in case
+    /// it fits in-place with the new size).
+    ///
+    /// If `p` is null, it behaves as [`mi_malloc_aligned`]. If `newsize` is
+    /// larger than the original `size` allocated for `p`, the bytes after
+    /// `size` are uninitialized.
+    pub fn mi_realloc_aligned(p: *mut c_void, newsize: usize, alignment: usize) -> *mut c_void;
+
+    /// Free previously allocated memory.
+    ///
+    /// The pointer `p` must have been allocated before (or be null).
     pub fn mi_free(p: *mut c_void);
+
+    /// Return the available bytes in a memory block.
+    ///
+    /// The returned size can be used to call [`mi_expand`] successfully.
     pub fn mi_usable_size(p: *mut c_void) -> usize;
 }
 

--- a/libmimalloc-sys/src/lib.rs
+++ b/libmimalloc-sys/src/lib.rs
@@ -65,8 +65,8 @@ extern "C" {
 
     /// Return the available bytes in a memory block.
     ///
-    /// The returned size can be used to call [`mi_expand`] successfully.
-    pub fn mi_usable_size(p: *mut c_void) -> usize;
+    /// The returned size can be used to call `mi_expand` successfully.
+    pub fn mi_usable_size(p: *const c_void) -> usize;
 }
 
 #[cfg(test)]

--- a/libmimalloc-sys/src/lib.rs
+++ b/libmimalloc-sys/src/lib.rs
@@ -2,6 +2,11 @@
 
 use core::ffi::c_void;
 
+#[cfg(feature = "extended")]
+mod extended;
+#[cfg(feature = "extended")]
+pub use extended::*;
+
 extern "C" {
     /// Allocate zero-initialized `size` bytes.
     ///

--- a/libmimalloc-sys/sys-test/Cargo.toml
+++ b/libmimalloc-sys/sys-test/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "libmimalloc-sys-test"
+version = "0.1.0"
+authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
+edition = "2018"
+description = "Bindings test for libmimalloc-sys"
+license = "MIT"
+publish = false
+
+[dependencies]
+libmimalloc-sys = { path = "..", features = ["extended"] }
+libc = "0.2"
+
+[build-dependencies]
+ctest = "0.2"

--- a/libmimalloc-sys/sys-test/build.rs
+++ b/libmimalloc-sys/sys-test/build.rs
@@ -1,0 +1,39 @@
+fn main() {
+    let mut cfg = ctest::TestGenerator::new();
+    cfg.header("mimalloc.h")
+        .include(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../c_src/mimalloc/include"
+        ))
+        .cfg("feature", Some("extended"))
+        .fn_cname(|rust, link_name| link_name.unwrap_or(rust).to_string())
+        // ignore whether or not the option enum is signed.
+        .skip_signededness(|c| c.ends_with("_t") || c.ends_with("_e"))
+        .type_name(|ty, _is_struct, _is_union| {
+            match ty {
+                // Special cases. We do this to avoid having both
+                // `mi_blah_{s,e}` and `mi_blah_t`.
+                "mi_heap_area_t" => "struct mi_heap_area_s".into(),
+                "mi_heap_t" => "struct mi_heap_s".into(),
+                "mi_options_t" => "enum mi_options_e".into(),
+
+                // This also works but requires we export `mi_heap_s` and similar
+                // in addition, so we just hardcode the above.
+
+                // t if t.ends_with("_s") => format!("struct {}", t),
+                // t if t.ends_with("_e") => format!("enum {}", t),
+                // t if t.ends_with("_t") => t.to_string(),
+
+                // mimalloc defines it's callbacks with the pointer at the
+                // location of use, e.g. `typedef ret mi_some_fun(a0 x, a1 y);`
+                // and then uses `mi_some_fun *arg` as argument types, which
+                // appears to upset ctest, which would prefer function pointers
+                // be declared as pointers, so we clean things up for it.
+                t if t.ends_with("_fun") => format!("{}*", t),
+
+                t => t.to_string(),
+            }
+        });
+
+    cfg.generate("../src/lib.rs", "all.rs");
+}

--- a/libmimalloc-sys/sys-test/src/main.rs
+++ b/libmimalloc-sys/sys-test/src/main.rs
@@ -1,0 +1,5 @@
+#![allow(bad_style, clippy::all)]
+
+use libmimalloc_sys::*;
+
+include!(concat!(env!("OUT_DIR"), "/all.rs"));


### PR DESCRIPTION
Fixes #31. Comes with tests, more CI, and docs.

This goes on top of #30 since it improves the CI. It also includes the fix for #29 which is a one-liner and is required to make the tests pass. 

Once #30 that lands I'll rebase and the commits from it should go away, and if you like the look at this I can close #29 and just let it get subsumed.

This splits stuff into an "extended" API (activated by a feature) and a default API. This is a bit odd, since it's not really on a good/deliberate boundary.

I think perhaps a better boundary would be:

- The minimal API is just the things needed by the `mimalloc::Mimalloc` implementation
- The extended API is everything else.

As it is it's kind of weird that it includes `mi_zalloc` or `mi_usable_size` in the "core", but `mi_calloc` is part of the extended api. That said, the code is probably fine as-is -- it would be breaking to move public stuff behind a feature, and really there's little benefit to it, so it seems fine, just odd.

# What this skips:

I'm not that attached to most of the things on this list, and would be willing to add them either now or in the future as-needed.

Anyway, the following parts of the API are intentionally not exposed because they

- The [C++ wrappers](https://microsoft.github.io/mimalloc/group__cpp.html) as they're just the normal mimalloc API but with throwing C++ exceptions on failure, which is probably unsound.

- The [Posix](https://microsoft.github.io/mimalloc/group__posix.html) functions as they're all aliases or tiny wrappers for the normal mimalloc API.

- All of [these](https://github.com/microsoft/mimalloc/blob/v1.6.3/include/mimalloc.h#L332-L365) not captured by Posix/C++ (above).

- The [Typed Macros](https://microsoft.github.io/mimalloc/group__typed.html) for obvious reasons.

- The [Zero initialized re-allocation](https://microsoft.github.io/mimalloc/group__zeroinit.html) functions as they're easy to misuse (only valid on pointers coming from a zero-init alloc function in the first place).

- Anything labeled experimental, which is:
    - Most of the `option` enums (note that the docs for them are sadly a bit out of date too... https://github.com/microsoft/mimalloc/issues/266). Users can make their own constants if they need these, which honestly seems unlikely.

    - Also `mi_is_in_heap_region`, `mi_is_redirected`, `mi_reserve_huge_os_pages_interleave`, `mi_reserve_huge_os_pages_at`.

- Anything deprecated, e.g. `mi_reserve_huge_os_pages`.

- I'm also omitting a few other functions that are not very useful and have potential to cause problems:

    - `mi_option_enable`/`mi_option_disable`: Just a wrapper for `mi_option_set_enabled`, and had a different argument count in the past

      In practice this seems unlikely to matter, but given that they're just wrappers, no reason to risk it in case this crate allows linking to an external mimalloc in the future, and we get an older one.

I think that's it.

---

Looking at it again, zero initialized re-allocation is probably worth adding -- it's a low level API and that can help. It's easy to misuse, but that's why it's `unsafe`.

Hrm.