### PR TITLE
add links directive to libmimalloc-sys crate

### DIFF
--- a/libmimalloc-sys/Cargo.toml
+++ b/libmimalloc-sys/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["allocator", "encrypted-heap", "performance"]
 categories = ["allocator"]
 description = "Sys crate wrapping the mimalloc allocator"
 license = "MIT"
+links = "mimalloc"
 
 [dependencies]
 


### PR DESCRIPTION
ensures at most one copy of mimalloc is linked, see https://doc.rust-lang.org/cargo/reference/manifest.html#the-links-field