### PR TITLE
Introduce local_dynamic_tls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ libmimalloc-sys = { path = "libmimalloc-sys", version = "0.1.17", default-featur
 default = ["secure"]
 secure = ["libmimalloc-sys/secure"]
 override = ["libmimalloc-sys/override"]
+local_dynamic_tls = ["libmimalloc-sys/local_dynamic_tls"]

--- a/libmimalloc-sys/Cargo.toml
+++ b/libmimalloc-sys/Cargo.toml
@@ -20,6 +20,7 @@ cmake = "0.1"
 secure = []
 override = []
 extended = ["cty"]
+local_dynamic_tls = []
 
 # Show `extended` on docs.rs since it's the full API surface.
 [package.metadata.docs.rs]

--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -78,6 +78,12 @@ fn main() {
         cfg = cfg.define("MI_SECURE", "OFF");
     }
 
+    if cfg!(feature = "local_dynamic_tls") {
+        cfg = cfg.define("MI_LOCAL_DYNAMIC_TLS", "ON");
+    } else {
+        cfg = cfg.define("MI_LOCAL_DYNAMIC_TLS", "OFF");
+    }
+
     // Inject MI_DEBUG=0
     // This set mi_option_verbose and mi_option_show_errors options to false.
     cfg = cfg.define("mi_defines", "MI_DEBUG=0");


### PR DESCRIPTION
Hello,

We are experiencing `cannot allocate memory in static TLS block` error when trying to `dlopen` shared libraries built with mimalloc, same thing is happening with jemallocator but we can solve it by `disable_initial_exec_tls` [feature flag](https://github.com/gnzlbg/jemallocator/blob/master/jemalloc-sys/README.md#cargo-features).
For more information see: https://github.com/microsoft/mimalloc/issues/147

This pull request adds new feature flag with name consistent with cmake build flag, `local_dynamic_tls`.