### PR TITLE
Update extended options, fix build

### DIFF
--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -95,6 +95,14 @@ fn main() {
         Ok(CMakeBuildType::MinSizeRel) => (false, "MinSizeRel"),
         Err(e) => panic!("Cannot determine CMake build type: {}", e),
     };
+
+    // Turning off shared lib, tests, PADDING.
+    // See also: https://github.com/microsoft/mimalloc/blob/master/CMakeLists.txt
+    cfg = cfg.define("MI_PADDING", "OFF");
+    cfg = cfg.define("MI_BUILD_TESTS", "OFF");
+    cfg = cfg.define("MI_BUILD_SHARED", "OFF");
+    cfg = cfg.define("MI_BUILD_OBJECT", "OFF");
+
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
     if target_env == "msvc" {
         cfg = cfg.define("CMAKE_SH", "CMAKE_SH-NOTFOUND");
@@ -114,10 +122,10 @@ fn main() {
         //  Those flags prevents mimalloc from building on windows
         if is_debug {
             // CMAKE_C_FLAGS + CMAKE_C_FLAGS_DEBUG
-            cfg = cfg.cflag("-static -ffunction-sections -fdata-sections -m64 -O2 -fpic");
+            cfg = cfg.cflag("-ffunction-sections -fdata-sections -m64 -O2 -fpic");
         } else {
             // CMAKE_C_FLAGS + CMAKE_C_FLAGS_RELEASE
-            cfg = cfg.cflag("-static -ffunction-sections -fdata-sections -m64 -O3 -fpic");
+            cfg = cfg.cflag("-ffunction-sections -fdata-sections -m64 -O3 -fpic");
         }
     };
 

--- a/libmimalloc-sys/src/extended.rs
+++ b/libmimalloc-sys/src/extended.rs
@@ -371,8 +371,11 @@ pub const mi_option_large_os_pages: mi_option_t = 6;
 /// allocate just a little to take up space in the huge OS page area (which cannot be reset).
 pub const mi_option_reserve_huge_os_pages: mi_option_t = 7;
 
+/// TODO: update later
+pub const mi_option_reserve_os_memory: mi_option_t = 8;
+
 /// Option (experimental) specifying number of segments per thread to keep cached.
-pub const mi_option_segment_cache: mi_option_t = 8;
+pub const mi_option_segment_cache: mi_option_t = 9;
 
 /// Option (experimental) to reset page memory after mi_option_reset_delay milliseconds when it becomes free.
 ///
@@ -384,19 +387,19 @@ pub const mi_option_segment_cache: mi_option_t = 8;
 /// off completely.
 ///
 /// Default: 1 (true)
-pub const mi_option_page_reset: mi_option_t = 9;
+pub const mi_option_page_reset: mi_option_t = 10;
 
 /// Experimental
-pub const mi_option_abandoned_page_reset: mi_option_t = 10;
+pub const mi_option_abandoned_page_reset: mi_option_t = 11;
 
 /// Experimental
-pub const mi_option_segment_reset: mi_option_t = 11;
+pub const mi_option_segment_reset: mi_option_t = 12;
 
 /// Experimental
-pub const mi_option_eager_commit_delay: mi_option_t = 12;
+pub const mi_option_eager_commit_delay: mi_option_t = 13;
 
 /// Option (experimental) specifying delay in milli-seconds before resetting a page (100ms by default).
-pub const mi_option_reset_delay: mi_option_t = 13;
+pub const mi_option_reset_delay: mi_option_t = 14;
 
 /// Option (experimental) to pretend there are at most N NUMA nodes.
 ///
@@ -405,13 +408,16 @@ pub const mi_option_reset_delay: mi_option_t = 13;
 /// actual NUMA nodes is fine and will only cause threads to potentially allocate more
 /// memory across actual NUMA nodes (but this can happen in any case as NUMA local
 /// allocation is always a best effort but not guaranteed).
-pub const mi_option_use_numa_nodes: mi_option_t = 14;
+pub const mi_option_use_numa_nodes: mi_option_t = 15;
+
+/// TODO: update later
+pub const mi_option_limit_os_alloc: mi_option_t = 16;
 
 /// Option (experimental) specifying OS tag to assign to mimalloc'd memory.
-pub const mi_option_os_tag: mi_option_t = 15;
+pub const mi_option_os_tag: mi_option_t = 17;
 
 /// Experimental
-pub const mi_option_max_errors: mi_option_t = 16;
+pub const mi_option_max_errors: mi_option_t = 18;
 
 extern "C" {
     // Note: mi_option_{enable,disable} aren't exposed because they're redundant


### PR DESCRIPTION
This PR address several issues:
- Outdated mi_options
- Turning off unused cmake target (shared lib, tests)
- Remove `-static` flag which forces linking to `static version of libc`. This behavior is not recommended and causes failure build on various env