### PR TITLE
Replace cmake with cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 ## Requirements
 
-[CMake](https://cmake.org/) and a __C__ compiler are required for building 
-[mimalloc](https://github.com/microsoft/mimalloc) with cargo.
+A __C__ compiler are required for building [mimalloc](https://github.com/microsoft/mimalloc) with cargo.
 
 ## Usage without secure mode
 
-By default this library builds mimalloc in secure mode. This add guard pages, 
+By default this library builds mimalloc in secure mode. This add guard pages,
 randomized allocation, encrypted free lists, etc. The performance penalty is usually
 around 10% according to [mimalloc](https://github.com/microsoft/mimalloc)
 own benchmarks.
 
 To disable secure mode, put in `Cargo.toml`:
-```rust
+
+```ini
 [dependencies]
 mimalloc = { version = "*", default-features = false }
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 ## Requirements
 
-A __C__ compiler are required for building [mimalloc](https://github.com/microsoft/mimalloc) with cargo.
+A __C__ compiler is required for building [mimalloc](https://github.com/microsoft/mimalloc) with cargo.
 
 ## Usage without secure mode
 

--- a/libmimalloc-sys/Cargo.toml
+++ b/libmimalloc-sys/Cargo.toml
@@ -14,7 +14,7 @@ links = "mimalloc"
 cty = { version = "0.2", optional = true }
 
 [build-dependencies]
-cmake = "0.1"
+cc = "1.0"
 
 [features]
 secure = []

--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -1,168 +1,64 @@
-#![allow(clippy::collapsible_if)]
-use cmake::Config;
 use std::env;
 
-enum CMakeBuildType {
-    Debug,
-    Release,
-    RelWithDebInfo,
-    MinSizeRel,
-}
-
-/// Determine the CMake build type that will be picked by `cmake-rs`.
-///
-/// This is mostly pasted from `cmake-rs`:
-/// https://github.com/alexcrichton/cmake-rs/blob/7f85e323/src/lib.rs#L498
-fn get_cmake_build_type() -> Result<CMakeBuildType, String> {
-    fn getenv(v: &str) -> Result<String, String> {
-        env::var(v).map_err(|_| format!("environment variable `{}` not defined", v))
-    }
-
-    // Determine Rust's profile, optimization level, and debug info:
-    #[derive(PartialEq)]
-    enum RustProfile {
-        Debug,
-        Release,
-    }
-    #[derive(PartialEq, Debug)]
-    enum OptLevel {
-        Debug,
-        Release,
-        Size,
-    }
-
-    let rust_profile = match getenv("PROFILE")?.as_str() {
-        "debug" => RustProfile::Debug,
-        "release" | "bench" => RustProfile::Release,
-        _ => RustProfile::Release,
-    };
-
-    let opt_level = match getenv("OPT_LEVEL")?.as_str() {
-        "0" => OptLevel::Debug,
-        "1" | "2" | "3" => OptLevel::Release,
-        "s" | "z" => OptLevel::Size,
-        _ => match rust_profile {
-            RustProfile::Debug => OptLevel::Debug,
-            RustProfile::Release => OptLevel::Release,
-        },
-    };
-
-    let debug_info: bool = match getenv("DEBUG")?.as_str() {
-        "false" => false,
-        "true" => true,
-        _ => true,
-    };
-
-    Ok(match (opt_level, debug_info) {
-        (OptLevel::Debug, _) => CMakeBuildType::Debug,
-        (OptLevel::Release, false) => CMakeBuildType::Release,
-        (OptLevel::Release, true) => CMakeBuildType::RelWithDebInfo,
-        (OptLevel::Size, _) => CMakeBuildType::MinSizeRel,
-    })
-}
-
 fn main() {
-    let mut cfg = &mut Config::new("c_src/mimalloc");
+    let mut build = cc::Build::new();
+
+    build.include("c_src/mimalloc/include");
+    build.files(
+        [
+            "alloc-aligned",
+            "alloc-posix",
+            "alloc",
+            "arena",
+            "bitmap",
+            "heap",
+            "init",
+            "options",
+            "os",
+            "page",
+            "random",
+            "region",
+            "segment",
+            "stats",
+        ]
+        .iter()
+        .map(|fname| format!("c_src/mimalloc/src/{}.c", fname)),
+    );
+
+    build.define("MI_STATIC_LIB", None);
+
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("target_os not defined!");
 
     if cfg!(feature = "override") {
-        cfg = cfg.define("MI_OVERRIDE", "ON");
-    } else {
-        cfg = cfg.define("MI_OVERRIDE", "OFF");
+        // Overriding malloc is only available on windows in shared mode, but we
+        // only ever build a static lib.
+        if target_os != "windows" {
+            build.define("MI_MALLOC_OVERRIDE", None);
+        }
     }
-
-    cfg = cfg.define("MI_BUILD_TESTS", "OFF");
 
     if cfg!(feature = "secure") {
-        cfg = cfg.define("MI_SECURE", "ON");
-    } else {
-        cfg = cfg.define("MI_SECURE", "OFF");
+        build.define("MI_SECURE", "4");
     }
 
-    if cfg!(feature = "local_dynamic_tls") {
-        cfg = cfg.define("MI_LOCAL_DYNAMIC_TLS", "ON");
-    } else {
-        cfg = cfg.define("MI_LOCAL_DYNAMIC_TLS", "OFF");
+    let dynamic_tls = cfg!(feature = "local_dynamic_tls");
+
+    if env::var("CARGO_CFG_TARGET_FAMILY").expect("target family not set") == "unix"
+        && target_os != "haiku"
+    {
+        if dynamic_tls {
+            build.flag_if_supported("-ftls-model=local-dynamic");
+        } else {
+            build.flag_if_supported("-ftls-model=initial-exec");
+        }
     }
 
-    // Inject MI_DEBUG=0
-    // This set mi_option_verbose and mi_option_show_errors options to false.
-    cfg = cfg.define("mi_defines", "MI_DEBUG=0");
+    // Remove heavy debug assertions etc
+    build.define("MI_DEBUG", "0");
 
-    let (is_debug, win_folder) = match get_cmake_build_type() {
-        Ok(CMakeBuildType::Debug) => (true, "Debug"),
-        Ok(CMakeBuildType::Release) => (false, "Release"),
-        Ok(CMakeBuildType::RelWithDebInfo) => (false, "RelWithDebInfo"),
-        Ok(CMakeBuildType::MinSizeRel) => (false, "MinSizeRel"),
-        Err(e) => panic!("Cannot determine CMake build type: {}", e),
-    };
-
-    // Turning off shared lib, tests, PADDING.
-    // See also: https://github.com/microsoft/mimalloc/blob/master/CMakeLists.txt
-    cfg = cfg.define("MI_PADDING", "OFF");
-    cfg = cfg.define("MI_BUILD_TESTS", "OFF");
-    cfg = cfg.define("MI_BUILD_SHARED", "OFF");
-    cfg = cfg.define("MI_BUILD_OBJECT", "OFF");
-
-    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    if target_env == "msvc" {
-        cfg = cfg.define("CMAKE_SH", "CMAKE_SH-NOTFOUND");
-
-        // cc::get_compiler have /nologo /MD default flags that are cmake::Config
-        // defaults to. Those flags prevents mimalloc from building on windows
-        // extracted from default cmake configuration on windows
-        if is_debug {
-            // CMAKE_C_FLAGS + CMAKE_C_FLAGS_DEBUG
-            cfg = cfg.cflag("/DWIN32 /D_WINDOWS /W3 /MDd /Zi /Ob0 /Od /RTC1");
-        } else {
-            // CMAKE_C_FLAGS + CMAKE_C_FLAGS_RELEASE
-            cfg = cfg.cflag("/DWIN32 /D_WINDOWS /W3 /MD /O2 /Ob2 /DNDEBUG");
-        }
-    } else if target_env == "gnu" {
-        cfg = cfg.define("CMAKE_SH", "CMAKE_SH-NOTFOUND");
-        //  Those flags prevents mimalloc from building on windows
-        if is_debug {
-            // CMAKE_C_FLAGS + CMAKE_C_FLAGS_DEBUG
-            cfg = cfg.cflag("-ffunction-sections -fdata-sections -m64 -O2 -fpic");
-        } else {
-            // CMAKE_C_FLAGS + CMAKE_C_FLAGS_RELEASE
-            cfg = cfg.cflag("-ffunction-sections -fdata-sections -m64 -O3 -fpic");
-        }
-    };
-
-    let mut out_dir = "./build".to_string();
-    if cfg!(all(windows)) {
-        if target_env == "msvc" {
-            out_dir.push('/');
-            out_dir.push_str(win_folder);
-        }
+    if build.get_compiler().is_like_msvc() {
+        build.cpp(true);
     }
-    let out_name = if cfg!(all(windows)) {
-        if is_debug {
-            if cfg!(feature = "secure") {
-                "mimalloc-static-secure-debug"
-            } else {
-                "mimalloc-static-debug"
-            }
-        } else if cfg!(feature = "secure") {
-            "mimalloc-static-secure"
-        } else {
-            "mimalloc-static"
-        }
-    } else if is_debug {
-        if cfg!(feature = "secure") {
-            "mimalloc-secure-debug"
-        } else {
-            "mimalloc-debug"
-        }
-    } else if cfg!(feature = "secure") {
-        "mimalloc-secure"
-    } else {
-        "mimalloc"
-    };
 
-    // Build mimalloc-static
-    let mut dst = cfg.build_target("mimalloc-static").build();
-    dst.push(out_dir);
-    println!("cargo:rustc-link-search=native={}", dst.display());
-    println!("cargo:rustc-link-lib={}", out_name);
+    build.compile("mimalloc");
 }


### PR DESCRIPTION
This PR replaces the usage of cmake with just straight usage of cc. It replicates some of the logic in the cmakelists but is simplified since this crate only builds a static lib.

Resolves: #51 