### PR TITLE
mingw tests failing, add Bcrypt lib

### DIFF
--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -28,6 +28,7 @@ fn main() {
     build.define("MI_STATIC_LIB", None);
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("target_os not defined!");
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").expect("target_env not defined!");
 
     if cfg!(feature = "override") {
         // Overriding malloc is only available on windows in shared mode, but we
@@ -61,4 +62,7 @@ fn main() {
     }
 
     build.compile("mimalloc");
+    if (target_os == "windows") && (target_env == "gnu") {
+        println!("cargo:rustc-link-lib=bcrypt");
+    }
 }


### PR DESCRIPTION
The mingw test are failing on random.c which is needing the bcrypt library.

   Compiling cc v1.0.67
   Compiling libmimalloc-sys v0.1.21 (D:\fork\mimalloc_rust\libmimalloc-sys)
warning: c_src/mimalloc/src/random.c:168: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
warning:   168 | #pragma comment (lib,"bcrypt.lib")
warning:       |
warning: c_src/mimalloc/src/stats.c:453: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
warning:   453 | #pragma comment(lib,"psapi.lib")
warning:       |
   Compiling mimalloc v0.1.25 (D:\fork\mimalloc_rust)
error: linking with `x86_64-w64-mingw32-gcc` failed: exit code: 1
  |
  = note: "x86_64-w64-mingw32-gcc" "-fno-use-linker-plugin" "-Wl,--nxcompat" "-Wl,--dynamicbase" "-Wl,--
disable-auto-image-base" "-m64" "-Wl,--high-entropy-va" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x
86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\rsbegin.o" "-L" "C:\\Users\\RyanC\\.rust
up\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib" "D:\\fork\\mimal
loc_rust\\target\\x86_64-pc-windows-gnu\\debug\\deps\\mimalloc-baa2274ebc188289.2dtv1k1zz9qvmgfy.rcgu.o"
 "D:\\fork\\mimalloc_rust\\target\\x86_64-pc-windows-gnu\\debug\\deps\\mimalloc-baa2274ebc188289.3o6yek1
rz4665s66.rcgu.o" "D:\\fork\\mimalloc_rust\\target\\x86_64-pc-windows-gnu\\debug\\deps\\mimalloc-baa2274
ebc188289.hto3d83cghmealt.rcgu.o" "D:\\fork\\mimalloc_rust\\target\\x86_64-pc-windows-gnu\\debug\\deps\\
mimalloc-baa2274ebc188289.uev7f2cumw3h0y4.rcgu.o" "D:\\fork\\mimalloc_rust\\target\\x86_64-pc-windows-gn
u\\debug\\deps\\mimalloc-baa2274ebc188289.uuzz9vbhvvjdfpp.rcgu.o" "D:\\fork\\mimalloc_rust\\target\\x86_
64-pc-windows-gnu\\debug\\deps\\mimalloc-baa2274ebc188289.yx3h5ejg3dxoi95.rcgu.o" "-o" "D:\\fork\\mimall
oc_rust\\target\\x86_64-pc-windows-gnu\\debug\\deps\\mimalloc-baa2274ebc188289.exe" "D:\\fork\\mimalloc_
rust\\target\\x86_64-pc-windows-gnu\\debug\\deps\\mimalloc-baa2274ebc188289.1io9srar1owan1r5.rcgu.o" "-W
l,--gc-sections" "-nodefaultlibs" "-L" "D:\\fork\\mimalloc_rust\\target\\x86_64-pc-windows-gnu\\debug\\d
eps" "-L" "D:\\fork\\mimalloc_rust\\target\\debug\\deps" "-L" "D:\\fork\\mimalloc_rust\\target\\x86_64-p
c-windows-gnu\\debug\\build\\libmimalloc-sys-64ad0b633479649a\\out" "-L" "C:\\Users\\RyanC\\.rustup\\too
lchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib" "-Wl,-Bstatic" "C:\\Use
rs\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\
libtest-1e958ba7f2fd6c0c.rlib" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib
\\rustlib\\x86_64-pc-windows-gnu\\lib\\libterm-665adbf1362c372c.rlib" "C:\\Users\\RyanC\\.rustup\\toolch
ains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libgetopts-8c59e2b6c5926ec
0.rlib" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-wi
ndows-gnu\\lib\\libunicode_width-c53c41973b34f2b1.rlib" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x
86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\librustc_std_workspace_std-719f2eaad2b28
cc0.rlib" "D:\\fork\\mimalloc_rust\\target\\x86_64-pc-windows-gnu\\debug\\deps\\liblibmimalloc_sys-366d3
6e9f0abc7b0.rlib" "-Wl,--start-group" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windows-g
nu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libstd-c1f4a34954f44b86.rlib" "C:\\Users\\RyanC\\.rustup\\
toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libpanic_unwind-63d9
18f6a4328727.rlib" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x
86_64-pc-windows-gnu\\lib\\libobject-df02665a14c23c3f.rlib" "C:\\Users\\RyanC\\.rustup\\toolchains\\stab
le-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libaddr2line-8a2ca8def5625c96.rlib"
"C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gn
u\\lib\\libgimli-f8602c621ed79cb5.rlib" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windows
-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\librustc_demangle-8124381f500c8a69.rlib" "C:\\Users\\Rya
nC\\.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libhash
brown-2260daa86b23c242.rlib" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\
rustlib\\x86_64-pc-windows-gnu\\lib\\librustc_std_workspace_alloc-5b3ec382765aebe0.rlib" "C:\\Users\\Rya
nC\\.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libunwi
nd-58f1a51695d3489d.rlib" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rus
tlib\\x86_64-pc-windows-gnu\\lib\\libcfg_if-46b81e008718457e.rlib" "C:\\Users\\RyanC\\.rustup\\toolchain
s\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\liblibc-f4a48eaff8400529.rlib
" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-
gnu\\lib\\liballoc-7094347f61afa1d3.rlib" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windo
ws-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\librustc_std_workspace_core-be0238fd280e8b76.rlib" "C:
\\Users\\RyanC\\.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\
lib\\libcore-bb3b979426878ebc.rlib" "-Wl,--end-group" "C:\\Users\\RyanC\\.rustup\\toolchains\\stable-x86
_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libcompiler_builtins-021a8bc03364b43c.rlib
" "-Wl,-Bdynamic" "-lkernel32" "-ladvapi32" "-lws2_32" "-luserenv" "-fuse-ld=lld" "-lgcc_eh" "-l:libpthr
ead.a" "-lmsvcrt" "-lmingwex" "-lmingw32" "-lgcc" "-lmsvcrt" "-luser32" "-lkernel32" "C:\\Users\\RyanC\\
.rustup\\toolchains\\stable-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\rsend.o"
  = note: lld-link: error: undefined symbol: BCryptGenRandom
          >>> referenced by c_src/mimalloc/src\random.c:171
          >>>               liblibmimalloc_sys-366d36e9f0abc7b0.rlib(random.o):(.text$os_random_buf)
          collect2.exe: error: ld returned 1 exit status


with bcrypt added:
(base) D:\fork\mimalloc_rust>cargo test --target x86_64-pc-windows-gnu
   Compiling libmimalloc-sys v0.1.21 (D:\fork\mimalloc_rust\libmimalloc-sys)
warning: c_src/mimalloc/src/random.c:168: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
warning:   168 | #pragma comment (lib,"bcrypt.lib")
warning:       |
warning: c_src/mimalloc/src/stats.c:453: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
warning:   453 | #pragma comment(lib,"psapi.lib")
warning:       |
   Compiling mimalloc v0.1.25 (D:\fork\mimalloc_rust)
    Finished test [unoptimized + debuginfo] target(s) in 12.90s
     Running target\x86_64-pc-windows-gnu\debug\deps\mimalloc-baa2274ebc188289.exe

running 6 tests
test tests::it_frees_allocated_big_memory ... ok
test tests::it_frees_allocated_memory ... ok
test tests::it_frees_zero_allocated_big_memory ... ok
test tests::it_frees_reallocated_memory ... ok
test tests::it_frees_zero_allocated_memory ... ok
test tests::it_frees_reallocated_big_memory ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

