### PR TITLE
Mark `libmimalloc_sys` as `no_std` to support `no_std` users.

### DIFF
--- a/libmimalloc-sys/src/lib.rs
+++ b/libmimalloc-sys/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 // Copyright 2019 Octavian Oncescu
 
 use core::ffi::c_void;


### PR DESCRIPTION
The `mimalloc_ruust` library is marked as `#![no_std]`, yet `libmimalloc-sys` is not marked as `#![no_std]` so `no_std` users of `mimalloc_rust` will pull in the `std` library as a result. This seems like a small oversight.

My specific use-case for this change is because I wish to create a library that does not link to `std` for a smaller size, but that still requires allocations.

I did not thoroughly check if this will adversely affect other end users, I'm hoping CI/CD will catch these.