### PR TITLE
Expose mimalloc's debug mode with a "debug" cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ libmimalloc-sys = { path = "libmimalloc-sys", version = "0.1.22", default-featur
 default = ["secure"]
 secure = ["libmimalloc-sys/secure"]
 override = ["libmimalloc-sys/override"]
+debug = ["libmimalloc-sys/debug"]
 local_dynamic_tls = ["libmimalloc-sys/local_dynamic_tls"]

--- a/libmimalloc-sys/Cargo.toml
+++ b/libmimalloc-sys/Cargo.toml
@@ -18,6 +18,7 @@ cc = "1.0"
 
 [features]
 secure = []
+debug = []
 override = []
 extended = ["cty"]
 local_dynamic_tls = []

--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -32,8 +32,13 @@ fn main() {
         }
     }
 
-    // Remove heavy debug assertions etc
-    build.define("MI_DEBUG", "0");
+    if env::var_os("CARGO_FEATURE_DEBUG").is_some() {
+        build.define("MI_DEBUG", "3");
+        build.define("MI_SHOW_ERRORS", "1");
+    } else {
+        // Remove heavy debug assertions etc
+        build.define("MI_DEBUG", "0");
+    }
 
     if build.get_compiler().is_like_msvc() {
         build.cpp(true);


### PR DESCRIPTION
Add a new cargo feature `"debug"` to enable a lot of debug checks within mimalloc.

Doesn't seem to fully function on Windows since the atexit handler never runs, for some reason. The handler does seem to run on other platforms so you get some extra debug output there.