### PR TITLE
Add license text to libmimalloc-sys crate

### DIFF
--- a/libmimalloc-sys/LICENSE.txt
+++ b/libmimalloc-sys/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt


### PR DESCRIPTION
Link the LICENSE.txt from the main project to the system crate.

This allows `cargo package` to bundle it up into the crate, as required for distribution packaging.

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>