### PR TITLE
Remove unnecessary files

### DIFF
--- a/libmimalloc-sys/Cargo.toml
+++ b/libmimalloc-sys/Cargo.toml
@@ -9,6 +9,14 @@ categories = ["memory-management", "api-bindings"]
 description = "Sys crate wrapping the mimalloc allocator"
 license = "MIT"
 links = "mimalloc"
+exclude = [
+    "/c_src/mimalloc/bin",
+    "/c_src/mimalloc/cmake",
+    "/c_src/mimalloc/doc",
+    "/c_src/mimalloc/docs",
+    "/c_src/mimalloc/ide",
+    "/c_src/mimalloc/test",
+]
 
 [dependencies]
 cty = { version = "0.2", optional = true }


### PR DESCRIPTION
The -sys package includes several MiB of completely unnecessary files, this just removes them from the package.