### PR TITLE
Remove `actions-rs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,45 +29,27 @@ jobs:
           submodules: recursive
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          profile: minimal
-          default: true
 
       - name: Build (secure)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
 
       - name: Test (secure)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
       - name: Test libmimalloc-sys crate bindings (secure)
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p libmimalloc-sys-test
+        run: cargo run -p libmimalloc-sys-test
 
       - name: Build (no secure)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --no-default-features
+        run: cargo build --no-default-features
 
       - name: Test (no secure)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features
+        run: cargo test --no-default-features
 
       - name: Test libmimalloc-sys crate bindings (no secure)
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --no-default-features -p libmimalloc-sys-test
+        run: cargo run --no-default-features -p libmimalloc-sys-test
 
   lint:
     name: Rustfmt / Clippy
@@ -78,23 +60,15 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
           components: rustfmt, clippy
 
       - name: Fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace -- -D warnings
+        run: cargo clippy --workspace -- -D warnings
 
   # Detect cases where documentation links would be dead
   doc:
@@ -106,11 +80,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - uses: dtolnay/rust-toolchain@nightly
 
       # Note: We need to use nightly rust, and `cargo rustdoc` (yes, not `cargo
       # doc`) to actually get it to respect -D warnings... Using nightly also
@@ -118,13 +88,7 @@ jobs:
       # what docs.rs uses.
 
       - name: 'Check documentation links in `mimalloc`'
-        uses: actions-rs/cargo@v1
-        with:
-          command: rustdoc
-          args: -- -D warnings
+        run: cargo rustdoc -- -D warnings
 
       - name: 'Check documentation links in `libmimalloc-sys`'
-        uses: actions-rs/cargo@v1
-        with:
-          command: rustdoc
-          args: -p libmimalloc-sys -- -D warnings
+        run: cargo rustdoc -p libmimalloc-sys -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,22 +34,22 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Build (secure)
-        run: cargo build
+        run: cargo build --features secure
 
       - name: Test (secure)
-        run: cargo test
+        run: cargo test --features secure
 
       - name: Test libmimalloc-sys crate bindings (secure)
-        run: cargo run -p libmimalloc-sys-test
+        run: cargo run --features secure -p libmimalloc-sys-test
 
       - name: Build (no secure)
-        run: cargo build --no-default-features
+        run: cargo build
 
       - name: Test (no secure)
-        run: cargo test --no-default-features
+        run: cargo test
 
       - name: Test libmimalloc-sys crate bindings (no secure)
-        run: cargo run --no-default-features -p libmimalloc-sys-test
+        run: cargo run -p libmimalloc-sys-test
 
   lint:
     name: Rustfmt / Clippy


### PR DESCRIPTION
[The `actions-rs` actions seem unmaintained.](https://github.com/actions-rs/toolchain/issues/216) I have removed all of them and replaced them with https://github.com/dtolnay/rust-toolchain, which seems like the most popular alternative.

I have also updated all of the actions/checkout actions from v3 to v4.

I also noticed that the `secure` feature was not being tested, so I fixed that issue.

I can split these up into separate PRs if requested.