### PR TITLE
Fix mi_usable_size gating

### DIFF
--- a/libmimalloc-sys/src/extended.rs
+++ b/libmimalloc-sys/src/extended.rs
@@ -1014,6 +1014,16 @@ mod tests {
     use super::*;
 
     #[test]
+    fn it_calculates_usable_size() {
+        let ptr = unsafe { mi_malloc(32) } as *mut u8;
+        let usable_size = unsafe { mi_usable_size(ptr as *mut c_void) };
+        assert!(
+            usable_size >= 32,
+            "usable_size should at least equal to the allocated size"
+        );
+    }
+
+    #[test]
     fn runtime_stable_option() {
         unsafe {
             assert_eq!(mi_option_get(mi_option_show_errors), 0);

--- a/libmimalloc-sys/src/lib.rs
+++ b/libmimalloc-sys/src/lib.rs
@@ -89,14 +89,4 @@ mod tests {
         let ptr = unsafe { mi_realloc_aligned(ptr as *mut c_void, 8, 8) } as *mut u8;
         unsafe { mi_free(ptr as *mut c_void) };
     }
-
-    #[test]
-    fn it_calculates_usable_size() {
-        let ptr = unsafe { mi_malloc(32) } as *mut u8;
-        let usable_size = unsafe { mi_usable_size(ptr as *mut c_void) };
-        assert!(
-            usable_size >= 32,
-            "usable_size should at least equal to the allocated size"
-        );
-    }
 }


### PR DESCRIPTION
mi_usable_size was gated behind the extended feature in https://github.com/purpleprotocol/mimalloc_rust/commit/310ffbef61e6647e134b849a5616475ad7475c98#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759

but one test, `it_calculates_usable_size` was left behind in `lib.rs`.

Move it to `extended.rs` as well.