### PR TITLE
Remove `dylib` from atomic linking

### DIFF
--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -57,6 +57,6 @@ fn main() {
 
     // on armv6 we need to link with libatomic
     if target_os == "linux" && target_arch == "arm" {
-        println!("cargo:rustc-link-lib=dylib=atomic");
+        println!("cargo:rustc-link-lib=atomic");
     }
 }


### PR DESCRIPTION
The `dylib` addition breaks static binaries causing them not never be static again, because the atomic lib is always added as a dynamic library.

Removing the `dylib` should not be an issue, since the compiler will either add it dynamically or statically based upon the compiler settings.