### PR TITLE
Update mimalloc submodule to v2.1.9 and set branch to master in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libmimalloc-sys/c_src/mimalloc"]
 	path = libmimalloc-sys/c_src/mimalloc
 	url = https://github.com/microsoft/mimalloc
+	branch = master


### PR DESCRIPTION
Updated the mimalloc submodule to version `v2.1.9` (2025-01-03), the latest stable release on the `master` branch. Updated `.gitmodules` to track `master` for future updates.