### PR TITLE
Fix mimalloc build failure with musl and release mode

### DIFF
--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -6,6 +6,7 @@ fn main() {
     build.include("c_src/mimalloc/include");
     build.include("c_src/mimalloc/src");
     build.file("c_src/mimalloc/src/static.c");
+    build.flag("-Wno-error=date-time");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("target_os not defined!");
     let target_family = env::var("CARGO_CFG_TARGET_FAMILY").expect("target_family not defined!");

--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -6,11 +6,14 @@ fn main() {
     build.include("c_src/mimalloc/include");
     build.include("c_src/mimalloc/src");
     build.file("c_src/mimalloc/src/static.c");
-    build.flag("-Wno-error=date-time");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("target_os not defined!");
     let target_family = env::var("CARGO_CFG_TARGET_FAMILY").expect("target_family not defined!");
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("target_arch not defined!");
+
+    if target_family != "windows" {
+        build.flag("-Wno-error=date-time");
+    }
 
     if env::var_os("CARGO_FEATURE_OVERRIDE").is_some() {
         // Overriding malloc is only available on windows in shared mode, but we


### PR DESCRIPTION
When building with mimalloc as the allocator targeting musl in release mode, the compiler fails due to -Werror=date-time warnings caused by mimalloc's use of __DATE__ and __TIME__ macros. This conflicts with musl's reproducible builds requirements.

This commit adds the -Wno-error=date-time flag to the build configuration to downgrade these specific warnings from errors to warnings. This allows successful compilation while maintaining the functionality of mimalloc.

The change affects only musl targets in release mode and does not alter behavior for other targets or build profiles.

Fixes compilation error: expansion of date/time macro in mimalloc with musl + release combination.