### PR TITLE
Provide the include directory to consumers

### DIFF
--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::path::Path;
 
 fn main() {
     let mut build = cc::Build::new();
@@ -8,6 +9,18 @@ fn main() {
     } else {
         "v2"
     };
+
+    let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let include_dir = Path::new(&cargo_manifest_dir)
+        .join("c_src/mimalloc/")
+        .join(version)
+        .join("include")
+        .to_str()
+        .expect("include path is not valid UTF-8")
+        .to_string();
+    // Make the include directory available to consumers via the `DEP_MIMALLOC_INCLUDE_DIR`
+    // environment variable.
+    println!("cargo:INCLUDE_DIR={include_dir}");
 
     build.include(format!("c_src/mimalloc/{version}/include"));
     build.include(format!("c_src/mimalloc/{version}/src"));


### PR DESCRIPTION
For users using both C/C++ and Rust, it's useful to have access to the mimalloc include directory in the build-script (of crates directly depending on `libmimalloc-sys`). This mechanism is also already used in crates like libz-sys, see https://github.com/rust-lang/libz-sys/blob/80c597a07f5e5f0dff0e98c03d48a77845de9f6e/build.rs#L171
This allows using the mimalloc implementation provided by this crate for both Rust and C/C++ code, without needing to vendor the mimalloc header.

See <https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key> for documentation.