### PR TITLE
feat: expose mi_stats_get_json and a safe wrapper around it

### DIFF
--- a/libmimalloc-sys/src/extended.rs
+++ b/libmimalloc-sys/src/extended.rs
@@ -447,6 +447,12 @@ extern "C" {
     ///
     /// Note: This function is thread safe.
     pub fn mi_register_error(out: mi_error_fun, arg: *mut c_void);
+
+    /// Get the statistics for the current subprocess aggregated over all its heaps as JSON.
+    ///
+    /// Returns pointer to the buffer or NULL on failure. Use mi_free() to free the buffer if the buf parameter was NULL.
+    #[cfg(not(feature = "v2"))]
+    pub fn mi_stats_get_json(buf_size: usize, buf: *mut c_char) -> *mut c_char;
 }
 
 /// An output callback. Must be thread-safe.
@@ -1092,7 +1098,7 @@ mod tests {
 
     #[test]
     fn it_calculates_usable_size() {
-        let ptr = unsafe { mi_malloc(32) } as *mut u8;
+        let ptr = unsafe { crate::mi_malloc(32) } as *mut u8;
         let usable_size = unsafe { mi_usable_size(ptr as *mut c_void) };
         assert!(
             usable_size >= 32,

--- a/libmimalloc-sys/src/extended.rs
+++ b/libmimalloc-sys/src/extended.rs
@@ -1094,11 +1094,12 @@ extern "C" {
 
 #[cfg(test)]
 mod tests {
+    use super::super::mi_malloc;
     use super::*;
 
     #[test]
     fn it_calculates_usable_size() {
-        let ptr = unsafe { crate::mi_malloc(32) } as *mut u8;
+        let ptr = unsafe { mi_malloc(32) } as *mut u8;
         let usable_size = unsafe { mi_usable_size(ptr as *mut c_void) };
         assert!(
             usable_size >= 32,

--- a/libmimalloc-sys/sys-test/build.rs
+++ b/libmimalloc-sys/sys-test/build.rs
@@ -55,5 +55,11 @@ fn main() {
             }
         });
 
+    if version == "v3" {
+        cfg.header("mimalloc-stats.h").include(format!(
+            "{cargo_manifest_dir}/../c_src/mimalloc/{version}/include"
+        ));
+    }
+
     cfg.generate("../src/lib.rs", "all.rs");
 }

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -20,27 +20,46 @@ impl MiMalloc {
         ffi::mi_usable_size(ptr as *const c_void)
     }
 
-    /// Call the given function with a string version of the JSON stats for the whole process
+    /// Extract a string containing the JSON statistics for the whole process
     ///
     /// Allocates (using mimalloc itself) to store the JSON structure.
     #[cfg(not(feature = "v2"))]
-    pub fn with_stats_json<F, O>(f: F) -> Result<O, &'static str>
-    where
-        F: FnOnce(&str) -> O,
-    {
+    pub fn stats_json() -> Result<StatsJson, &'static str> {
         unsafe {
             let buf = ffi::mi_stats_get_json(0, core::ptr::null::<c_char>() as *mut _);
-            if buf.is_null() {
-                return Err("failed to call mi_stats_get_json");
+            if let Some(inner) = core::ptr::NonNull::new(buf) {
+                Ok(StatsJson { inner })
+            } else {
+                Err("failed to call mi_stats_get_json")
             }
-            let cstr = CStr::from_ptr(buf);
-            let slice = cstr
-                .to_str()
-                .map_err(|_| "mi_stats_get_json contained invalid UTF-8")?;
-            let o = f(slice);
-            ffi::mi_free(buf as _);
-            Ok(o)
         }
+    }
+}
+
+#[cfg(not(feature = "v2"))]
+/// Wrapper around the output of `MiMalloc::stats_json()`
+///
+/// Derefs to a CStr
+pub struct StatsJson {
+    inner: core::ptr::NonNull<c_char>,
+}
+
+#[cfg(not(feature = "v2"))]
+impl core::ops::Deref for StatsJson {
+    type Target = CStr;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            let cstr = CStr::from_ptr(self.inner.as_ptr());
+            &cstr
+        }
+    }
+}
+
+#[cfg(not(feature = "v2"))]
+impl Drop for StatsJson {
+    fn drop(&mut self) {
+        unsafe { ffi::mi_free(self.inner.as_ptr() as _) }
     }
 }
 
@@ -71,9 +90,10 @@ mod test {
 
     #[test]
     #[cfg(not(feature = "v2"))]
-    fn test_with_stats_json() {
-        let (first_char, len) = MiMalloc::with_stats_json(|f| (f.chars().next(), f.len())).unwrap();
-        assert_eq!(first_char, Some('{'));
-        assert!(len > 1);
+    fn test_stats_json() {
+        let stats = MiMalloc::stats_json().expect("should get stats");
+        let slice = stats.to_str().expect("should be valid UTF-8");
+        assert_eq!(slice.chars().next(), Some('{'));
+        assert!(stats.count_bytes() > 1);
     }
 }

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -1,5 +1,7 @@
 use crate::MiMalloc;
 use core::ffi::c_void;
+#[cfg(not(feature = "v2"))]
+use core::ffi::{c_char, CStr};
 
 impl MiMalloc {
     /// Get the mimalloc version.
@@ -16,6 +18,29 @@ impl MiMalloc {
     #[inline]
     pub unsafe fn usable_size(&self, ptr: *const u8) -> usize {
         ffi::mi_usable_size(ptr as *const c_void)
+    }
+
+    /// Call the given function with a string version of the JSON stats for the whole process
+    ///
+    /// Allocates (using mimalloc itself) to store the JSON structure.
+    #[cfg(not(feature = "v2"))]
+    pub fn with_stats_json<F, O>(f: F) -> Result<O, &'static str>
+    where
+        F: FnOnce(&str) -> O,
+    {
+        unsafe {
+            let buf = ffi::mi_stats_get_json(0, core::ptr::null::<c_char>() as *mut _);
+            if buf.is_null() {
+                return Err("failed to call mi_stats_get_json");
+            }
+            let cstr = CStr::from_ptr(buf);
+            let slice = cstr
+                .to_str()
+                .map_err(|_| "mi_stats_get_json contained invalid UTF-8")?;
+            let o = f(slice);
+            ffi::mi_free(buf as _);
+            Ok(o)
+        }
     }
 }
 
@@ -42,5 +67,13 @@ mod test {
             alloc.dealloc(ptr, layout);
             assert!(usable_size >= 8);
         }
+    }
+
+    #[test]
+    #[cfg(not(feature = "v2"))]
+    fn test_with_stats_json() {
+        let (first_char, len) = MiMalloc::with_stats_json(|f| (f.chars().next(), f.len())).unwrap();
+        assert_eq!(first_char, Some('{'));
+        assert!(len > 1);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! own benchmarks.
 //!
 //! To enable secure mode, put in `Cargo.toml`:
-//! ```rust,ignore
+//! ```toml
 //! [dependencies]
 //! mimalloc = { version = "*", features = ["secure"] }
 //! ```


### PR DESCRIPTION
mimalloc v3 added the cool new `mi_stats_get_json()` function to expose a ton of useful information about the allocator as semistructured JSON. This is a pretty minimal API that exposes this function and lets users bring their own parser/etc for reading the data.

A perhaps more elegant alternative would be exposing `mi_stats_get()` instead, but that requires bridging the `mi_stats` structure into Rust, which would probably bring us into the realm of `bindgen`.

See #150 for a related request