### PR TITLE
Use /MDd flag to compile in debug mode if cargo is in debug mode

### DIFF
--- a/libmimalloc-sys/build.rs
+++ b/libmimalloc-sys/build.rs
@@ -51,6 +51,10 @@ fn main() {
         build.std("c++17");
         build.flag_if_supported("/Zc:__cplusplus");
 
+        if cargo_debug {
+            build.flag("/MDd");
+        }
+
         let wrapper =
             PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set")).join("mimalloc-static.cc");
         let include = static_source.to_string_lossy().replace('\\', "/");


### PR DESCRIPTION
If `mimalloc_rust` is used in conjunction with another msvc library, it needs to set the correct run-time library version (as specified by [this microsoft doc](https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2012/2kzt1wy3(v=vs.110)?redirectedfrom=MSDN)). Previously, `mimalloc_rust` was always building mimalloc_rust in `DynamicRelease` mode, which would conflict with other libraries building against msvc who were correctly respecting the debug level (and building in `DynamicDebug` mode).

This issue can be seen in the [CI runs of this PR](https://github.com/itsjunetime/tdf/pull/154), where mupdf-rs was correctly building in debug mode when cargo was building in debug mode, but the mimalloc DLL was building in release mode still. The linker refused to link the libraries together because of the differing runtime library mode.

As you can see from the later commits on the aforementioned PR, this change fixes the issue. For some reason, using `build.flag_if_supported` didn't do the trick - I guess the build system isn't aware that `/MDd` is a valid flag.