### PR TITLE
perf(alloc): skip ``*_aligned` calls when alignment fits default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,15 +50,36 @@ use ffi::*;
 /// ```
 pub struct MiMalloc;
 
+/// The minimum alignment that mimalloc's default allocation functions
+/// (`mi_malloc` / `mi_zalloc`) guarantee for every block, regardless of the
+/// requested `Layout::align()`.
+///
+/// This mirrors mimalloc's `MI_MAX_ALIGN_SIZE` constant (`sizeof(max_align_t)`,
+/// 16 bytes on most platforms), despite the "MAX" in its C name actually
+/// denoting a guaranteed *minimum* alignment.
+const MIN_MIMALLOC_ALIGNMENT: usize = 16;
+
+/// The alignment threshold below which mimalloc's `realloc` internally
+/// falls back to the unaligned reallocation path.
+///
+/// Corresponds to mimalloc's internal check
+/// `alignment <= sizeof(uintptr_t)` inside
+/// `mi_theap_realloc_zero_aligned_at`, which delegates to
+/// `_mi_theap_realloc_zero` when the alignment does not exceed the size of
+/// a pointer (8 bytes on 64-bit platforms, 4 on 32-bit).
+///
+/// Note this differs from [`MIN_MIMALLOC_ALIGNMENT`], which is 16: mimalloc
+/// does not use the same threshold for `realloc` as it does for `malloc`.
+const MIN_REALLOC_ALIGNMENT: usize = size_of::<usize>();
+
 unsafe impl GlobalAlloc for MiMalloc {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        mi_malloc_aligned(layout.size(), layout.align()) as *mut u8
-    }
-
-    #[inline]
-    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        mi_zalloc_aligned(layout.size(), layout.align()) as *mut u8
+        if layout.align() <= MIN_MIMALLOC_ALIGNMENT {
+            mi_malloc(layout.size()) as *mut u8
+        } else {
+            mi_malloc_aligned(layout.size(), layout.align()) as *mut u8
+        }
     }
 
     #[inline]
@@ -67,8 +88,21 @@ unsafe impl GlobalAlloc for MiMalloc {
     }
 
     #[inline]
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        if layout.align() <= MIN_MIMALLOC_ALIGNMENT {
+            mi_zalloc(layout.size()) as *mut u8
+        } else {
+            mi_zalloc_aligned(layout.size(), layout.align()) as *mut u8
+        }
+    }
+
+    #[inline]
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        mi_realloc_aligned(ptr as *mut c_void, new_size, layout.align()) as *mut u8
+        if layout.align() <= MIN_REALLOC_ALIGNMENT {
+            mi_realloc(ptr as *mut c_void, new_size) as *mut u8
+        } else {
+            mi_realloc_aligned(ptr as *mut c_void, new_size, layout.align()) as *mut u8
+        }
     }
 }
 
@@ -78,69 +112,57 @@ mod tests {
 
     #[test]
     fn it_frees_allocated_memory() {
-        unsafe {
-            let layout = Layout::from_size_align(8, 8).unwrap();
-            let alloc = MiMalloc;
+        let layout = Layout::from_size_align(8, 8).unwrap();
+        let alloc = MiMalloc;
 
-            let ptr = alloc.alloc(layout);
-            alloc.dealloc(ptr, layout);
-        }
+        let ptr = unsafe { alloc.alloc(layout) };
+        unsafe { alloc.dealloc(ptr, layout) };
     }
 
     #[test]
     fn it_frees_allocated_big_memory() {
-        unsafe {
-            let layout = Layout::from_size_align(1 << 20, 32).unwrap();
-            let alloc = MiMalloc;
+        let layout = Layout::from_size_align(1 << 20, 32).unwrap();
+        let alloc = MiMalloc;
 
-            let ptr = alloc.alloc(layout);
-            alloc.dealloc(ptr, layout);
-        }
+        let ptr = unsafe { alloc.alloc(layout) };
+        unsafe { alloc.dealloc(ptr, layout) };
     }
 
     #[test]
     fn it_frees_zero_allocated_memory() {
-        unsafe {
-            let layout = Layout::from_size_align(8, 8).unwrap();
-            let alloc = MiMalloc;
+        let layout = Layout::from_size_align(8, 8).unwrap();
+        let alloc = MiMalloc;
 
-            let ptr = alloc.alloc_zeroed(layout);
-            alloc.dealloc(ptr, layout);
-        }
+        let ptr = unsafe { alloc.alloc_zeroed(layout) };
+        unsafe { alloc.dealloc(ptr, layout) };
     }
 
     #[test]
     fn it_frees_zero_allocated_big_memory() {
-        unsafe {
-            let layout = Layout::from_size_align(1 << 20, 32).unwrap();
-            let alloc = MiMalloc;
+        let layout = Layout::from_size_align(1 << 20, 32).unwrap();
+        let alloc = MiMalloc;
 
-            let ptr = alloc.alloc_zeroed(layout);
-            alloc.dealloc(ptr, layout);
-        }
+        let ptr = unsafe { alloc.alloc_zeroed(layout) };
+        unsafe { alloc.dealloc(ptr, layout) };
     }
 
     #[test]
     fn it_frees_reallocated_memory() {
-        unsafe {
-            let layout = Layout::from_size_align(8, 8).unwrap();
-            let alloc = MiMalloc;
+        let layout = Layout::from_size_align(8, 8).unwrap();
+        let alloc = MiMalloc;
 
-            let ptr = alloc.alloc(layout);
-            let ptr = alloc.realloc(ptr, layout, 16);
-            alloc.dealloc(ptr, layout);
-        }
+        let ptr = unsafe { alloc.alloc(layout) };
+        let ptr = unsafe { alloc.realloc(ptr, layout, 16) };
+        unsafe { alloc.dealloc(ptr, layout) };
     }
 
     #[test]
     fn it_frees_reallocated_big_memory() {
-        unsafe {
-            let layout = Layout::from_size_align(1 << 20, 32).unwrap();
-            let alloc = MiMalloc;
+        let layout = Layout::from_size_align(1 << 20, 32).unwrap();
+        let alloc = MiMalloc;
 
-            let ptr = alloc.alloc(layout);
-            let ptr = alloc.realloc(ptr, layout, 2 << 20);
-            alloc.dealloc(ptr, layout);
-        }
+        let ptr = unsafe { alloc.alloc(layout) };
+        let ptr = unsafe { alloc.realloc(ptr, layout, 2 << 20) };
+        unsafe { alloc.dealloc(ptr, layout) };
     }
 }


### PR DESCRIPTION
For my [library](https://github.com/lava-sh/toml-rs), this provides a small speedup (about ~3.2%):

```console
❯ py benchmark/b.py
file: example.toml
size: 3.93 KiB
runs: 1,000 x 5

allocator                 time    vs default        memory        wall
--------------------------------------------------------------------------
default               0.0514s        1.00x      15.39 MB     0.384s
mimalloc              0.0438s        1.17x      15.68 MB     0.331s
fp-mimalloc           0.0408s        1.26x      15.76 MB     0.306s
❯ py benchmark/b.py
file: example.toml
size: 3.93 KiB
runs: 1,000 x 5

allocator                 time    vs default        memory        wall
--------------------------------------------------------------------------
default               0.0493s        1.00x      15.25 MB     0.360s
mimalloc              0.0437s        1.13x      15.75 MB     0.321s
fp-mimalloc           0.0415s        1.19x      15.58 MB     0.316s
❯ py benchmark/b.py
file: example.toml
size: 3.93 KiB
runs: 1,000 x 5

allocator                 time    vs default        memory        wall
--------------------------------------------------------------------------
default               0.0530s        1.00x      15.20 MB     0.371s
mimalloc              0.0436s        1.22x      15.50 MB     0.322s
fp-mimalloc           0.0440s        1.21x      15.69 MB     0.321s
❯ py benchmark/b.py
file: example.toml
size: 3.93 KiB
runs: 1,000 x 5

allocator                 time    vs default        memory        wall
--------------------------------------------------------------------------
default               0.0541s        1.00x      15.33 MB     0.376s
mimalloc              0.0415s        1.30x      15.62 MB     0.306s
fp-mimalloc           0.0409s        1.32x      15.52 MB     0.317s
❯ py benchmark/b.py
file: example.toml
size: 3.93 KiB
runs: 1,000 x 5

allocator                 time    vs default        memory        wall
--------------------------------------------------------------------------
default               0.0494s        1.00x      15.17 MB     0.356s
mimalloc              0.0425s        1.16x      15.70 MB     0.323s
fp-mimalloc           0.0412s        1.20x      15.83 MB     0.322s
❯ py benchmark/b.py
file: example.toml
size: 3.93 KiB
runs: 1,000 x 5

allocator                 time    vs default        memory        wall
--------------------------------------------------------------------------
default               0.0540s        1.00x      15.18 MB     0.386s
mimalloc              0.0430s        1.26x      15.52 MB     0.321s
fp-mimalloc           0.0414s        1.30x      15.81 MB     0.313s
❯ py benchmark/b.py
file: example.toml
size: 3.93 KiB
runs: 1,000 x 5

allocator                 time    vs default        memory        wall
--------------------------------------------------------------------------
default               0.0512s        1.00x      15.14 MB     0.364s
mimalloc              0.0464s        1.10x      15.59 MB     0.335s
fp-mimalloc           0.0446s        1.15x      15.55 MB     0.321s
```